### PR TITLE
Update of the PUJetID for miniAOD V2

### DIFF
--- a/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
+++ b/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
@@ -1055,14 +1055,14 @@ int main(int argc, char* argv[])
              //jet id
              bool passPFloose = patUtils::passPFJetID("Loose", jets[ijet]);
              float PUDiscriminant = jets[ijet].userFloat("pileupJetId:fullDiscriminant");
-             bool passLooseSimplePuId = patUtils::passPUJetID(jets[ijet]); //Uses recommended value of HZZ, will update this as soon my analysis is done. (Hugo)
+             bool passLooseSimplePuId = patUtils::passPUJetID(jets[ijet]); //FIXME Broken in miniAOD V2 : waiting for JetMET fix. (Hugo)
              if(jets[ijet].pt()>30){
                  mon.fillHisto(jetType,"",fabs(jets[ijet].eta()),0);
                  if(passPFloose)                        mon.fillHisto(jetType,"",fabs(jets[ijet].eta()),1);
                  if(passLooseSimplePuId)                mon.fillHisto(jetType,"",fabs(jets[ijet].eta()),2);
                  if(passPFloose && passLooseSimplePuId) mon.fillHisto(jetType,"",fabs(jets[ijet].eta()),3);
              }
-             if(!passPFloose || !passLooseSimplePuId) continue;
+             if(!passPFloose /*|| !passLooseSimplePuId*/) continue; //FIXME PUJetID is broken in miniAOD V2 : waiting for JetMET fix (Hugo)
              selJets.push_back(jets[ijet]);
              if(jets[ijet].pt()>30) {
                njets++;

--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -518,23 +518,26 @@ namespace patUtils
     double jeta = j.eta();
 
     //Recommendation of HZZ :https://twiki.cern.ch/twiki/bin/view/CMS/HiggsZZ4l2015#Jets
+    //FIXME recommendation of HZZ are oudated (run 1)--->update them
+    //FIXME Progress: Partially done (removed the cuts at eta>2.75) but have to wait for improvements from JetMET group
+    //FIXME In miniAOD V2, the variable used is bugged ! Please avoir using it!
     float jpumva=0.;
     jpumva=j.userFloat("pileupJetId:fullDiscriminant");
 
     bool passPU = true;
     if(jpt>20){
       if(jeta>3.){
-        if(jpumva<=-0.45)passPU=false;
+        //if(jpumva<=-0.45)passPU=false;
       }else if(jeta>2.75){
-        if(jpumva<=-0.55)passPU=false;
+        //if(jpumva<=-0.55)passPU=false;
       }else if(jeta>2.5){
         if(jpumva<=-0.6)passPU=false;
       }else if(jpumva<=-0.63)passPU=false;
     }else{ //pt<20 : in the 2l2nu analysis, this means 15<pt<20
       if(jeta>3.){
-        if(jpumva<=-0.95)passPU=false;
+        //if(jpumva<=-0.95)passPU=false;
       }else if(jeta>2.75){
-        if(jpumva<=-0.94)passPU=false;
+        //if(jpumva<=-0.94)passPU=false;
       }else if(jeta>2.5){
         if(jpumva<=-0.96)passPU=false;
       }else if(jpumva<=-0.95)passPU=false;


### PR DESCRIPTION
This PR was also made in https://github.com/quertenmont/2l2v_fwk/pull/53 

Update of the PUJetID lookinga at miniAOD V1
1) Suppression of the cuts at high pseudo-rapidity in PatUtils.cc

Update of the PUJetID looking at miniAOD V2
2) Since miniAOD V2 are bugged for the PUJetID, suppression of this cleaning in the hzz2l2nu code
