### PR TITLE
Updated electron ID to pat::Electron class

### DIFF
--- a/bin/chhiggs/runAnalysis.cc
+++ b/bin/chhiggs/runAnalysis.cc
@@ -333,7 +333,7 @@ int main (int argc, char *argv[])
   const edm::ParameterSet& myVidElectronIdConf = runProcess.getParameterSet("electronidparas");
   const edm::ParameterSet& myVidElectronIdWPConf = myVidElectronIdConf.getParameterSet("tight");
   
-  VersionedGsfElectronSelector electronVidId(myVidElectronIdWPConf);
+  VersionedPatElectronSelector electronVidId(myVidElectronIdWPConf);
   
   TString suffix = runProcess.getParameter < std::string > ("suffix");
   std::vector < std::string > urls = runProcess.getUntrackedParameter < std::vector < std::string > >("input");
@@ -694,8 +694,8 @@ int main (int argc, char *argv[])
 
 
   TString
-    electronIdMainTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose"),
-    electronIdVetoTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight");
+    electronIdMainTag("cutBasedElectronID-Spring15-25ns-V1-standalone-loose"),
+    electronIdVetoTag("cutBasedElectronID-Spring15-25ns-V1-standalone-tight");
 
   //pileup weighting
   edm::LumiReWeighting * LumiWeights = NULL;
@@ -1127,15 +1127,11 @@ int main (int argc, char *argv[])
           //Cut based identification 
           
           //std::vector<pat::Electron> dummyShit; dummyShit.push_back(leptons[ilep].el);
-
-          bool passMyId = electronVidId(leptons[ilep].el, myEvent);   //patUtils::passId(electronVidId, myEvent, leptons[ilep].el);
-
-          cout << "ID IS " << passMyId << endl;
-
+          
           
           passId = lid == 11 ? patUtils::passId(electronVidId, myEvent, leptons[ilep].el) : patUtils::passId(leptons[ilep].mu, goodPV, patUtils::llvvMuonId::StdTight);
 
-            //passId          = lid == 11 ? (leptons[ilep].el.electronID(electronIdMainTag)==7) : patUtils::passId(leptons[ilep].mu, goodPV, patUtils::llvvMuonId::StdTight);
+          //passId          = lid == 11 ? (leptons[ilep].el.electronID(electronIdMainTag)==7) : patUtils::passId(leptons[ilep].mu, goodPV, patUtils::llvvMuonId::StdTight);
           passVetoId      = lid == 11 ? (leptons[ilep].el.electronID(electronIdVetoTag)==7) : patUtils::passId(leptons[ilep].mu, goodPV, patUtils::llvvMuonId::StdLoose);
 
           //isolation

--- a/interface/PatUtils.h
+++ b/interface/PatUtils.h
@@ -32,7 +32,7 @@
 #include "UserCode/llvv_fwk/interface/LumiUtils.h"
 
 // Electron ID
-#include "RecoEgamma/ElectronIdentification/interface/VersionedGsfElectronSelector.h"
+#include "RecoEgamma/ElectronIdentification/interface/VersionedPatElectronSelector.h"
 
 #include <vector>
 #include "TVector3.h"
@@ -62,10 +62,11 @@ namespace patUtils
    namespace llvvElecIso{ enum ElecIso {Veto, Loose, Medium, Tight}; }
    namespace llvvMuonIso{ enum MuonIso {Loose,Tight}; }
 
-   bool passId (VersionedGsfElectronSelector id, edm::EventBase const & event, pat::Electron& el);
+   bool passId (VersionedPatElectronSelector id, edm::EventBase const & event, pat::Electron el);
    bool passId (pat::Electron& el,  reco::Vertex& vtx, int IdLevel); // Old PHYS14 ID
    bool passId (pat::Muon&     mu,  reco::Vertex& vtx, int IdLevel);
    bool passId (pat::Photon& photon,  double rho, int IdLevel);
+   bool passIso (VersionedPatElectronSelector id, pat::Electron& el);
    bool passIso(pat::Electron& el,  int IsoLevel, double rho=0.0); // Old PHYS15 Iso
    bool passIso(pat::Muon&     mu,  int IsoLevel);
    bool passPhotonTrigger(fwlite::ChainEvent ev, float &triggerThreshold, float &triggerPrescale); 

--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -5,9 +5,9 @@
 namespace patUtils
 {
 
-  bool passId (VersionedGsfElectronSelector id, edm::EventBase const & event, pat::Electron& el){
+  bool passId (VersionedPatElectronSelector id, edm::EventBase const & event, pat::Electron el){
     // This assumes an object to be created ( *before the event loop* ):
-    // VersionedGsfElectronSelector loose_id("some_VID_tag_including_the_WP");
+    // VersionedPatElectronSelector loose_id("some_VID_tag_including_the_WP");
     return id(el, event);
   }
   
@@ -286,9 +286,9 @@ namespace patUtils
     return false; 
   }
 
-  bool passIso (VersionedGsfElectronSelector id, pat::Electron& el){
+  bool passIso (VersionedPatElectronSelector id, pat::Electron& el){
     // This assumes an object to be created ( *before the event loop* ):
-    // VersionedGsfElectronSelector loose_id("some_VID_tag_including_the_WP");
+    // VersionedPatElectronSelector loose_id("some_VID_tag_including_the_WP");
     return true; // Isolation is now embedded into the ID.
   }
 


### PR DESCRIPTION
I realized that it was implicitly converting to GsfElectron.

Sorry for the double pull in a so short amount of time.