### PR TITLE
dropped split keyword + DY xsec switched from NNLO to NLO

### DIFF
--- a/test/hzz2l2v/photon_samples.json
+++ b/test/hzz2l2v/photon_samples.json
@@ -6,7 +6,7 @@
    "isdata":false,
    "color":831,
     "lcolor":1,                                                                                                                   
-   "data":[ { "dtag":"MC13TeV_DYJetsToLL_M-10to50", "split":40, "xsec":20657.1 , "br":[ 1.0 ] ,                                        
+   "data":[ { "dtag":"MC13TeV_DYJetsToLL_M-10to50",  "xsec":18610  , "br":[ 1.0 ] ,                                        
    "dset":"/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM"} 
     ]
     },
@@ -16,7 +16,7 @@
     "isdata":false,  
     "color":831,                                                                                                                         
     "lcolor":1,                                                                                                                    
-    "data":[ { "dtag":"MC13TeV_DYJetsToLL_50toInf", "split":40, "xsec":6025.3 , "br":[ 1.0 ] , 
+    "data":[ { "dtag":"MC13TeV_DYJetsToLL_50toInf",  "xsec":6025.3 , "br":[ 1.0 ] , 
     	       "dset":"/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v3/MINIAODSIM"}
      ]
     },
@@ -27,7 +27,7 @@
     "color":390,
     "lcolor":1,
      "data":[                                                                     
-      { "dtag":"MC13TeV_GJet_HT-40to100", "split":40, "xsec":23080.0, "br":[ 1.0 ],
+      { "dtag":"MC13TeV_GJet_HT-40to100",  "xsec":23080.0, "br":[ 1.0 ],
       "dset":"/GJets_HT-40To100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM"}
       ]
     },
@@ -38,7 +38,7 @@
     "color":390,
     "lcolor":1,
     "data":[
-	{ "dtag":"MC13TeV_GJet_HT-100to200", "split":40, "xsec":9110.0, "br":[ 1.0 ],
+	{ "dtag":"MC13TeV_GJet_HT-100to200",  "xsec":9110.0, "br":[ 1.0 ],
 	  "dset":"/GJets_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM"}
     ]
    },
@@ -49,7 +49,7 @@
     "color":390,
     "lcolor":1,	
     "data":[ 
-    { "dtag":"MC13TeV_GJet_HT-200to400", "split":40, "xsec":2281.0, "br":[ 1.0 ],
+    { "dtag":"MC13TeV_GJet_HT-200to400",  "xsec":2281.0, "br":[ 1.0 ],
     "dset":"/GJets_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM"}
     ]
     },
@@ -59,7 +59,7 @@
     "isdata":false,
     "color":390,
     "lcolor":1,
-    "data":[ {"dtag":"MC13TeV_GJet_HT-400to600", "split":40, "xsec":273.0, "br":[ 1.0 ],
+    "data":[ {"dtag":"MC13TeV_GJet_HT-400to600",  "xsec":273.0, "br":[ 1.0 ],
 	    "dset":"/GJets_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM"}
         ]
    },
@@ -69,7 +69,7 @@
     "isdata":false,
     "color":390,
     "lcolor":1,
-    "data":[{"dtag":"MC13TeV_GJet_HT-600toInf", "split":40, "xsec": 94.5   , "br":[ 1.0 ],             
+    "data":[{"dtag":"MC13TeV_GJet_HT-600toInf",  "xsec": 94.5   , "br":[ 1.0 ],             
 	    "dset":"/GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM"}
        ]
    } ,


### PR DESCRIPTION
Hi Xin,
Done .  Indeed the DY xsec I had put there for the 10<M<50 sample was the NNLO one , but for consistency with the DY M>50 sample we switch to the NLO values for both samples.
cheers, Georgia