### PR TITLE
Change version of VBF_H_ToZZ_M1000GeV Version

### DIFF
--- a/test/hzz2l2v/samples.json
+++ b/test/hzz2l2v/samples.json
@@ -105,12 +105,12 @@
       "fill":0,
       "marker":20,
       "data":[
-        { "dtag":"Data13TeV_DoubleElectron2015D_05Oct2015"       ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":"/DoubleEG/Run2015D-05Oct2015-v1/MINIAOD"     ,  "lumiMask":"Cert_251563-258159_13TeV_PromptReco_Collisions15_25ns_JSON_v3.txt"   },
-        { "dtag":"Data13TeV_DoubleMu2015D_05Oct2015"             ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":"/DoubleMuon/Run2015D-05Oct2015-v1/MINIAOD"   ,  "lumiMask":"Cert_251563-258159_13TeV_PromptReco_Collisions15_25ns_JSON_v3.txt"   },
-        { "dtag":"Data13TeV_MuEG2015D_05Oct2015"                 ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":"/MuonEG/Run2015D-05Oct2015-v2/MINIAOD"       ,  "lumiMask":"Cert_251563-258159_13TeV_PromptReco_Collisions15_25ns_JSON_v3.txt"   },
-        { "dtag":"Data13TeV_DoubleElectron2015D"       ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":"/DoubleEG/Run2015D-PromptReco-v4/MINIAOD"     ,  "lumiMask":"Cert_251563-258159_13TeV_PromptReco_Collisions15_25ns_JSON_v3.txt"   },
-        { "dtag":"Data13TeV_DoubleMu2015D"             ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":"/DoubleMuon/Run2015D-PromptReco-v4/MINIAOD"   ,  "lumiMask":"Cert_251563-258159_13TeV_PromptReco_Collisions15_25ns_JSON_v3.txt"   },
-        { "dtag":"Data13TeV_MuEG2015D"                 ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":"/MuonEG/Run2015D-PromptReco-v4/MINIAOD"       ,  "lumiMask":"Cert_251563-258159_13TeV_PromptReco_Collisions15_25ns_JSON_v3.txt"   }
+        { "dtag":"Data13TeV_DoubleElectron2015D_05Oct2015"       ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":"/DoubleEG/Run2015D-05Oct2015-v1/MINIAOD"     ,  "lumiMask":"/afs/cern.ch/work/a/amagitte/public/HZZ_Analysis_Run2/CMSSW_7_4_14/src/UserCode/llvv_fwk/test/hzz2l2v/Cert_251563-258159_13TeV_PromptReco_Collisions15_25ns_JSON_v3.txt"   },
+        { "dtag":"Data13TeV_DoubleMu2015D_05Oct2015"             ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":"/DoubleMuon/Run2015D-05Oct2015-v1/MINIAOD"   ,  "lumiMask":"/afs/cern.ch/work/a/amagitte/public/HZZ_Analysis_Run2/CMSSW_7_4_14/src/UserCode/llvv_fwk/test/hzz2l2v/Cert_251563-258159_13TeV_PromptReco_Collisions15_25ns_JSON_v3.txt"   },
+        { "dtag":"Data13TeV_MuEG2015D_05Oct2015"                 ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":"/MuonEG/Run2015D-05Oct2015-v2/MINIAOD"       ,  "lumiMask":"/afs/cern.ch/work/a/amagitte/public/HZZ_Analysis_Run2/CMSSW_7_4_14/src/UserCode/llvv_fwk/test/hzz2l2v/Cert_251563-258159_13TeV_PromptReco_Collisions15_25ns_JSON_v3.txt"   },
+        { "dtag":"Data13TeV_DoubleElectron2015D"       ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":"/DoubleEG/Run2015D-PromptReco-v4/MINIAOD"     ,  "lumiMask":"/afs/cern.ch/work/a/amagitte/public/HZZ_Analysis_Run2/CMSSW_7_4_14/src/UserCode/llvv_fwk/test/hzz2l2v/Cert_251563-258159_13TeV_PromptReco_Collisions15_25ns_JSON_v3.txt"   },
+        { "dtag":"Data13TeV_DoubleMu2015D"             ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":"/DoubleMuon/Run2015D-PromptReco-v4/MINIAOD"   ,  "lumiMask":"/afs/cern.ch/work/a/amagitte/public/HZZ_Analysis_Run2/CMSSW_7_4_14/src/UserCode/llvv_fwk/test/hzz2l2v/Cert_251563-258159_13TeV_PromptReco_Collisions15_25ns_JSON_v3.txt"   },
+        { "dtag":"Data13TeV_MuEG2015D"                 ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":"/MuonEG/Run2015D-PromptReco-v4/MINIAOD"       ,  "lumiMask":"/afs/cern.ch/work/a/amagitte/public/HZZ_Analysis_Run2/CMSSW_7_4_14/src/UserCode/llvv_fwk/test/hzz2l2v/Cert_251563-258159_13TeV_PromptReco_Collisions15_25ns_JSON_v3.txt"   }
       ]
     },
     {
@@ -195,7 +195,7 @@
       "lwidth":2,
       "lstyle":2,
       "fill":0,      "marker":1,      "data":[
-        { "dtag":"MC13TeV_VBFtoH1000toZZto2L2Nu_powheg15"     ,  "xsec":0.066      , "br":[0.311, 0.0135]    , "dset":"/VBF_HToZZTo2L2Nu_M1000_13TeV_powheg_JHUgen_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM", "dbsURL":"prod/global" }
+        { "dtag":"MC13TeV_VBFtoH1000toZZto2L2Nu_powheg15"     ,  "xsec":0.066      , "br":[0.311, 0.0135]    , "dset":"/VBF_HToZZTo2L2Nu_M1000_13TeV_powheg_JHUgen_pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v2/MINIAODSIM", "dbsURL":"prod/global" }
       ]
     }
   ]


### PR DESCRIPTION
Hi all,

the current version of the signal sample for VBF with Mass = 1000 GeV, present in the sample.json was tagged as INVALID. 
The proper version now is v2.

Alessio