### PR TITLE
fix when using METfilters with Run2015D

### DIFF
--- a/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
+++ b/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
@@ -117,7 +117,8 @@ int main(int argc, char* argv[])
   bool isMC_QCD = (isMC && dtag.Contains("QCD"));                                                                                   
   bool isMC_GJet = (isMC && dtag.Contains("GJet"));    
 
-  bool isPromptReco (!isMC && dtag.Contains("Run2015B-PromptReco")); //"False" picks up correctly the new prompt reco (2015C) and MC
+  //  bool isPromptReco (!isMC && dtag.Contains("Run2015B-PromptReco")); //"False" picks up correctly the new prompt reco (2015C) and MC
+  bool isPromptReco (!isMC && ( dtag.Contains("Run2015B-PromptReco") || dtag.Contains("Run2015D_PromptReco")) );
 
   TString outTxtUrl= outUrl + ".txt";    
   FILE* outTxtFile = NULL;

--- a/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
+++ b/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
@@ -117,8 +117,7 @@ int main(int argc, char* argv[])
   bool isMC_QCD = (isMC && dtag.Contains("QCD"));                                                                                   
   bool isMC_GJet = (isMC && dtag.Contains("GJet"));    
 
-  //  bool isPromptReco (!isMC && dtag.Contains("Run2015B-PromptReco")); //"False" picks up correctly the new prompt reco (2015C) and MC
-  bool isPromptReco (!isMC && ( dtag.Contains("Run2015B-PromptReco") || dtag.Contains("2015D_PromptReco")) );
+  bool isPromptReco (!isMC && dtag.Contains("PromptReco")); //"False" picks up correctly the new prompt reco (2015C) and MC
 
   TString outTxtUrl= outUrl + ".txt";    
   FILE* outTxtFile = NULL;

--- a/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
+++ b/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
@@ -118,7 +118,7 @@ int main(int argc, char* argv[])
   bool isMC_GJet = (isMC && dtag.Contains("GJet"));    
 
   //  bool isPromptReco (!isMC && dtag.Contains("Run2015B-PromptReco")); //"False" picks up correctly the new prompt reco (2015C) and MC
-  bool isPromptReco (!isMC && ( dtag.Contains("Run2015B-PromptReco") || dtag.Contains("Run2015D_PromptReco")) );
+  bool isPromptReco (!isMC && ( dtag.Contains("Run2015B-PromptReco") || dtag.Contains("2015D_PromptReco")) );
 
   TString outTxtUrl= outUrl + ".txt";    
   FILE* outTxtFile = NULL;

--- a/test/hzz2l2v/samples_ctrl.json
+++ b/test/hzz2l2v/samples_ctrl.json
@@ -122,7 +122,7 @@
        "marker":20,                                                                                                            
        "data":[         
         { "dtag":"Data13TeV_SinglePhoton2015D_05Oct2015"        ,  "xsec":1.0     , "br":[ 1.0 ]    , "dset":"/SinglePhoton/Run2015D-05Oct2015-v1/MINIAOD"      ,  "lumiMask":"Cert_246908-260426_13TeV_PromptReco_Collisions15_25ns_JSON.txt" },             
-       { "dtag":"Data13TeV_SinglePhoton2015D"                  ,  "xsec":1.0     , "br":[ 1.0 ]    , "dset":"/SinglePhoton/Run2015D-PromptReco-v4/MINIAOD"     ,  "lumiMask":"Cert_246908-260426_13TeV_PromptReco_Collisions15_25ns_JSON.txt" }               
+       { "dtag":"Data13TeV_SinglePhoton2015D_PromptReco"                  ,  "xsec":1.0     , "br":[ 1.0 ]    , "dset":"/SinglePhoton/Run2015D-PromptReco-v4/MINIAOD"     ,  "lumiMask":"Cert_246908-260426_13TeV_PromptReco_Collisions15_25ns_JSON.txt" }               
        ]                                                                                                                       
   },
       {


### PR DESCRIPTION
Hi @amagitte ,
I saw that one needs to put the variable "isPromptReco" to true for Run2015D PromptReco datasets as well (otherwise the code crashes , e.g. on SinglePhoton Run2015D PromptReco because of ProductNoFound in TriggerResults ) .
 Currently this variable is only set to true for RunB PromptReco . Do you agree to change this as in my fix here?
Thanks, Georgia