### PR TITLE
Patch scale factor units for stitching

### DIFF
--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -831,6 +831,8 @@ double alphaVariation(const fwlite::Event& ev){
         else if(lheHt>=400 && lheHt<600) htScaleFactor=0.0035837837;
         else if(lheHt>=600             ) htScaleFactor=0.0011156801;
       }                                     
+
+    htScaleFactor /= 1000; // The scale factors are derived for 1/fb, whereas we normalize in picobarns
     return htScaleFactor;                   
 
     // In order to use this stitching, you need to run a full set of HT-binned samples plus the inclusive one.


### PR DESCRIPTION
Hi guys,

sorry, I had forgotten to commit the line for rescaling the scale factors in order to use them when rescaling to a luminosity expressed in inverse picobarn (they are for luminosity expressed in inverse femtobarn). 
Tested, it works (it is actually what I had tested a couple days ago, but that last line was not in the latest commit)

Best,
Pietro