### PR TITLE
[For iihe people, please read] Simplification of the submission procedure for iihe

### DIFF
--- a/scripts/runAnalysisOverSamples.py
+++ b/scripts/runAnalysisOverSamples.py
@@ -47,11 +47,9 @@ def initProxy():
    if(not validCertificate):
       print "You are going to run on a sample over grid using either CRAB or the AAA protocol, it is therefore needed to initialize your grid certificate"
       if(not os.path.isfile(os.path.expanduser('~/.globus/mysecret.txt'))):
-         if(hostname.find("iihe.ac.be")!=-1): os.system('mkdir -p '+PROXYDIR+'; voms-proxy-init --voms cms:/cms/becms  -valid 192:00 --out '+PROXYDIR+'/x509_proxy')
-         else:                                os.system('mkdir -p '+PROXYDIR+'; voms-proxy-init --voms cms             -valid 192:00 --out '+PROXYDIR+'/x509_proxy')
+         os.system('mkdir -p '+PROXYDIR+'; voms-proxy-init --voms cms             -valid 192:00 --out '+PROXYDIR+'/x509_proxy')
       else:
-         if(hostname.find("iihe.ac.be")!=-1): os.system('mkdir -p '+PROXYDIR+'; voms-proxy-init --voms cms:/cms/becms  -valid 192:00 --out '+PROXYDIR+'/x509_proxy -pwstdin < /home/fynu/quertenmont/.globus/mysecret.txt')
-         else:                                os.system('mkdir -p '+PROXYDIR+'; voms-proxy-init --voms cms             -valid 192:00 --out '+PROXYDIR+'/x509_proxy -pwstdin < /home/fynu/quertenmont/.globus/mysecret.txt') 
+         os.system('mkdir -p '+PROXYDIR+'; voms-proxy-init --voms cms             -valid 192:00 --out '+PROXYDIR+'/x509_proxy -pwstdin < /home/fynu/quertenmont/.globus/mysecret.txt') 
    initialCommand = 'export X509_USER_PROXY='+PROXYDIR+'/x509_proxy;voms-proxy-init --voms cms --noregen; ' #no voms here, otherwise I (LQ) have issues
 
 def getFileList(procData,DefaultNFilesPerJob):


### PR DESCRIPTION
Due to an update of the procedure to get new certificates at IIHE, the submission procedure doesn't need anymore the becms argument.

Therefore I decided to partially port back the submission procedure, simplifying it by removing some specific iihe lines.

For iihe people:
-------------------------
If you are using a CERN certificate (and it is what is advised from now on --> only one certificate for everything), then it will work.
If you still use a old belnet certificate, you have two options:
 - adding by hand the --voms cms:/cms/becms in scripts/runAnalysisOverSamples.py when you run on m machines (see my commit)
 - follow this twiki (http://doc.iihe.ac.be/wiki/t2b/index.php/Getting_a_certificate_for_the_T2) to add your CERN certificate on the m machines instead of the belnet one.

If you have any question/complain, you know where my office is ;)


