### PR TITLE
Simplify submission and comply to new das client

### DIFF
--- a/scripts/runAnalysisOverSamples.py
+++ b/scripts/runAnalysisOverSamples.py
@@ -7,7 +7,6 @@ import LaunchOnCondor
 import UserCode.llvv_fwk.storeTools_cff as storeTools
 import sqlite3
 
-#PROXYDIR = "~/x509_user_proxy"
 DatasetFileDB = "DAS"  #DEFAULT: will use das_client.py command line interface
 #DatasetFileDB = "DBS" #OPTION:  will use curl to parse https GET request on DBSserver
 
@@ -68,29 +67,18 @@ initialCommand = '';
 def initProxy():
    global initialCommand
    validCertificate = True
-   #if(validCertificate and (not os.path.isfile(os.path.expanduser(PROXYDIR+'/x509_proxy')))):validCertificate = False
-   #if(validCertificate and (not os.path.isfile(os.path.expanduser(os.environ.get('X509_USER_PROXY'))))):validCertificate = False
-   #if(validCertificate and (time.time() - os.path.getmtime(os.path.expanduser(PROXYDIR+'/x509_proxy')))>600): validCertificate = False
-   #if(validCertificate and (time.time() - os.path.getmtime(os.path.expanduser(os.environ.get('X509_USER_PROXY'))))>600): validCertificate = False
-   # --voms cms, otherwise it does not work normally
    if(validCertificate and (not os.environ.get('X509_USER_PROXY', ''))): validCertificate = False
    if(validCertificate and (time.time() - os.path.getmtime(os.path.expanduser(os.environ.get('X509_USER_PROXY'))))>600): validCertificate = False
+   # --voms cms, otherwise it does not work normally
    if(validCertificate and int(commands.getstatusoutput('(voms-proxy-init --voms cms --noregen;voms-proxy-info -all) | grep timeleft | tail -n 1')[1].split(':')[2])<8 ):validCertificate = False
 
    if(not validCertificate):
       print "You are going to run on a sample over grid using either CRAB or the AAA protocol, it is therefore needed to initialize your grid certificate"
       if(not os.path.isfile(os.path.expanduser('~/.globus/mysecret.txt'))):
-         #os.system('mkdir -p '+PROXYDIR+'; voms-proxy-init --voms cms             -valid 192:00 --out '+PROXYDIR+'/x509_proxy')
          os.system('voms-proxy-init --voms cms             -valid 192:00')
       else:
-         #os.system('mkdir -p '+PROXYDIR+'; voms-proxy-init --voms cms             -valid 192:00 --out '+PROXYDIR+'/x509_proxy -pwstdin < /home/fynu/quertenmont/.globus/mysecret.txt') 
          os.system('voms-proxy-init --voms cms             -valid 192:00 -pwstdin < /home/fynu/quertenmont/.globus/mysecret.txt') 
    
-   #exportProxy = 'export X509_USER_PROXY='+PROXYDIR+'/x509_proxy'
-   #os.system(exportProxy) #needed for DAS queries
-   #print PROXYDIR
-   #print os.environ.get('X509_USER_PROXY')
-   #initialCommand = exportProxy+';voms-proxy-init --voms cms --noregen; ' #no voms here, otherwise I (LQ) have issues
    initialCommand = 'voms-proxy-init --voms cms --noregen; ' #no voms here, otherwise I (LQ) have issues
 
 def getFileList(procData,DefaultNFilesPerJob):
@@ -229,7 +217,6 @@ if(hostname.find("iihe.ac.be")!=-1):localTier = "T2_BE_IIHE"
 if(hostname.find("cern.ch")!=-1)  :localTier = "T2_CH_CERN"
 
 FarmDirectory                      = opt.outdir+"/FARM"
-#PROXYDIR                           = FarmDirectory+"/inputs/"
 initProxy()
 doCacheInputs                      = False
 if("IIHE" in localTier): doCacheInputs = True


### PR DESCRIPTION
Dear all,

1) The new DAS client requires to have a certificate to be used. Our code already asks for a certificate but link the specific path to this certificate too late in our submission procedure, leading to a fail in the submission procedure.

2) The addition of this specific path for the certificate instead of the default one was due to IIHE. Indeed, in the past IIHE couldn't use the default folder where is stored the proxy while submitting to the local grid.
However, IIHE system became recently more compatible with other sites and therefore this "trick" is not needed anymore.

This second point is the reason why, instead of just adding a line to add the specific path to the proxy before the das query, I chose to simplify the procedure by reverting to the default creation of proxies.
It sounds always better to me to simplify things as much as possible instead adding fixes over fixes. **However, am I right to say that only IIHE was affected or is there other sites where the default folder for proxies cannot be used during the submission?**
Thanks for commenting if you think this will cause issue in your site... and please test it then!

Best,

Hugo