### PR TITLE
additions and fixes for MC samples

### DIFF
--- a/test/hzz2l2v/samples2016.json
+++ b/test/hzz2l2v/samples2016.json
@@ -39,10 +39,11 @@
     },
     {
       "tag":"ZZ",
-      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_photoncontrol", "2l2v_datadriven_SM", "2l2v_datadriven_RsGrav", "2l2v_datadriven_BulkGrav", "2l2v_datadriven_Rad", "2l2v_mcbased_SM", "2l2v_mcbased_RsGrav", "2l2v_mcbased_BulkGrav", "2l2v_mcbased_Rad"],
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_photoncontrol", "2l2v_photonsOnly", "2l2v_datadriven_SM", "2l2v_datadriven_RsGrav", "2l2v_datadriven_BulkGrav", "2l2v_datadriven_Rad", "2l2v_mcbased_SM", "2l2v_mcbased_RsGrav", "2l2v_mcbased_BulkGrav", "2l2v_mcbased_Rad"],
       "isdata":false,
       "color":592,
-      "mctruthmode":1113,         
+      "mctruthmode":1113,
+      "2l2v_photonsOnly":{"suffix":"reweighted"},         
       "data":[
         { "dtag":"MC13TeV_ZZ2l2q_2016"                          ,  "xsec":3.22             , "br":[ 1.0 ]           , "dset":["/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
         { "dtag":"MC13TeV_ZZ2l2nu_2016"                         ,  "xsec":0.564            , "br":[ 1.0 ]           , "dset":["/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
@@ -100,9 +101,19 @@
         { "dtag":"MC13TeV_TTZJets2l2nu_2016"                      ,  "xsec":2.529e-01  , "br":[ 1 ] , "dset":["/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
       ]
     },
+    {
+       "tag":"W#rightarrow l#nu",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_mcbased_SM", "2l2v_mcbased_RsGrav", "2l2v_mcbased_BulkGrav", "2l2v_mcbased_Rad", "2l2v_datadriven", "2l2v_datadriven_SM", "2l2v_datadriven_RsGrav", "2l2v_datadriven_BulkGrav", "2l2v_datadriven_Rad"],
+     "isdata":false,
+      "color":809, 
+      "data":[ 
+        { "dtag":"MC13TeV_WJets_2016"                            ,  "xsec":61526.7       , "br":[ 0.15 ]  , "dset":["/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_WJets_ext1_2016"                            ,  "xsec":61526.7       , "br":[ 0.85 ]  , "dset":["/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]}
+      ]
+    },
      {
-	 "tag":"W#rightarrow l#nu",
-	 "keys":["2l2v_2016", "2l2v_mcbased","2l2v_photoncontrol", "2l2v_photonsOnly", "2l2v_datadriven", "2l2v_datadriven_SM", "2l2v_datadriven_RsGrav", "2l2v_datadriven_BulkGrav", "2l2v_datadriven_Rad", "2l2v_mcbased_SM", "2l2v_mcbased_RsGrav", "2l2v_mcbased_BulkGrav", "2l2v_mcbased_Rad"],
+     "tag":"W#rightarrow l#nu, HT>100",
+      "keys":["2l2v_2016", "2l2v_photoncontrol","2l2v_photonsOnly"],
       "isdata":false,
       "color":809,
       "2l2v_photonsOnly":{"suffix":"reweighted"},
@@ -120,46 +131,120 @@
       { "dtag":"MC13TeV_WJets_HT-1200To2500_ext1_2016"                            ,  "xsec":1.329       , "br":[ 0.5 ]                 , "dset":["/WJetsToLNu_HT-1200To2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
       { "dtag":"MC13TeV_WJets_HT-2500ToInf_2016"                            ,  "xsec":0.03216       , "br":[ 1.0 ]                 , "dset":["/WJetsToLNu_HT-2500ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
       ]
-    },
+     },
+      {
+     "tag":"W#rightarrow qq, HT>600",
+      "keys":["2l2v_2016", "2l2v_photoncontrol","2l2v_photonsOnly"],           
+      "isdata":false,
+      "color":810,
+      "2l2v_photonsOnly":{"suffix":"reweighted"},
+      "data":[
+	  { "dtag":"MC13TeV_WJetsToQQ_HT-600ToInf_2016",  "xsec":95.14        , "br":[ 1.0 ]   , "dset":["/WJetsToQQ_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+      ]
+      },
      {
       "tag":"Z#rightarrow #tau#tau",
-      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_photoncontrol", "2l2v_datadriven_SM", "2l2v_datadriven_RsGrav", "2l2v_datadriven_BulkGrav", "2l2v_datadriven_Rad", "2l2v_mcbased_SM", "2l2v_mcbased_RsGrav", "2l2v_mcbased_BulkGrav", "2l2v_mcbased_Rad"],      
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_photoncontrol","2l2v_photonsOnly", "2l2v_mcbased_SM", "2l2v_mcbased_RsGrav", "2l2v_mcbased_BulkGrav", "2l2v_mcbased_Rad","2l2v_datadriven", "2l2v_datadriven_SM", "2l2v_datadriven_RsGrav", "2l2v_datadriven_BulkGrav", "2l2v_datadriven_Rad"],      
       "mctruthmode":15,    
       "isdata":false,
       "color":833,
+      "2l2v_photonsOnly":{"suffix":"reweighted"},
       "data":[
         { "dtag":"MC13TeV_DYJetsToLL_10to50_2016"               ,  "xsec":18610     , "br":[ 1.0 ]    , "dset":["/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
         { "dtag":"MC13TeV_DYJetsToLL_50toInf_2016"              ,  "xsec":5765.4    , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
       ]
-    },   
+     },
+      {
+      "tag":"Z#rightarrow #tau#tau, HT>100",
+      "keys":["2l2v_2016"],
+      "mctruthmode":15,    
+      "isdata":false,
+      "color":834,
+	  "data":[
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-100To200_2016"               ,  "xsec":224.2 , "br":[ 1.0 ]   , "dset":["/DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-200To400_2016"               ,  "xsec":37.2 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-200To400_ext1_2016"               ,  "xsec":37.2 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-400To600_2016"               ,  "xsec":3.581 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-400To600_ext1_2016"               ,  "xsec":3.581 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-600ToInf_2016"               ,  "xsec":1.124 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-600ToInf_ext1_2016"               ,  "xsec":1.124 , "br":[ 0.5 ]   , "dset":[" /DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-100To200_2016"              ,  "xsec":147.40    , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-100To200_ext1_2016"              ,  "xsec":147.40    , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-200To400_2016"              ,  "xsec":40.99     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-200To400_ext1_2016"              ,  "xsec":40.99     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]}, 				 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-400To600_2016"              ,  "xsec":5.678     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-400To600_ext1_2016"              ,  "xsec":5.678     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-600To800_2016"              ,  "xsec":1.367     , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-600to800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-800To1200_2016"              ,  "xsec":0.6304      , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-800to1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-1200To2500_2016"              ,  "xsec":0.1514       , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-1200to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-2500ToInf_2016"              ,  "xsec":0.003565       , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-2500toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+	]
+     },
     {
       "tag":"Z#rightarrow ee/#mu#mu",
-      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_photoncontrol", "2l2v_mcbased_SM", "2l2v_mcbased_RsGrav", "2l2v_mcbased_BulkGrav", "2l2v_mcbased_Rad"],      
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_photoncontrol","2l2v_photonsOnly","2l2v_mcbased_SM", "2l2v_mcbased_RsGrav", "2l2v_mcbased_BulkGrav", "2l2v_mcbased_Rad"],
       "isdata":false,
       "mctruthmode":1113,    
       "color":831,
+      "2l2v_photonsOnly":{"suffix":"reweighted"},  
       "data":[
         { "dtag":"MC13TeV_DYJetsToLL_10to50_2016"               ,  "xsec":18610     , "br":[ 1.0 ]   , "dset":["/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
         { "dtag":"MC13TeV_DYJetsToLL_50toInf_2016"              ,  "xsec":5765.4    , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
       ]
     },
+   {
+      "tag":"Z#rightarrow ee/#mu#mu, HT>100",
+       "keys":["2l2v_2016"],
+      "isdata":false,
+      "mctruthmode":1113,    
+      "color":832,
+       "data":[
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-100To200_2016"               ,  "xsec":224.2 , "br":[ 1.0 ]   , "dset":["/DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-200To400_2016"               ,  "xsec":37.2 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-200To400_ext1_2016"               ,  "xsec":37.2 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-400To600_2016"               ,  "xsec":3.581 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-400To600_ext1_2016"               ,  "xsec":3.581 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-600ToInf_2016"               ,  "xsec":1.124 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-600ToInf_ext1_2016"               ,  "xsec":1.124 , "br":[ 0.5 ]   , "dset":[" /DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-100To200_2016"              ,  "xsec":147.40    , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-100To200_ext1_2016"              ,  "xsec":147.40    , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-200To400_2016"              ,  "xsec":40.99     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-200To400_ext1_2016"              ,  "xsec":40.99     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]}, 				 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-400To600_2016"              ,  "xsec":5.678     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-400To600_ext1_2016"              ,  "xsec":5.678     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-600To800_2016"              ,  "xsec":1.367     , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-600to800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-800To1200_2016"              ,  "xsec":0.6304      , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-800to1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-1200To2500_2016"              ,  "xsec":0.1514       , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-1200to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	   { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-2500ToInf_2016"              ,  "xsec":0.003565       , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-2500toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+	]
+    },																			  
     {
-    	"tag":"Z#rightarrow #nu#nu",
+      "tag":"Z#rightarrow #nu#nu",
       "keys":["2l2v_2016", "2l2v_photoncontrol", "2l2v_photonsOnly"],      
       "isdata":false,                                                                         
       "color":7,
       "2l2v_photonsOnly":{"suffix":"reweighted"},	
       "data":[                                                                                             
-        { "dtag":"MC13TeV_ZJetsToNuNu_HT-100To200_2016", "xsec":280.35, "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-100To200_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
-        { "dtag":"MC13TeV_ZJetsToNuNu_HT-200To400_2016", "xsec":78.36 , "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-200To400_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
-        { "dtag":"MC13TeV_ZJetsToNuNu_HT-400To600_2016", "xsec":10.94, "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-400To600_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
-        { "dtag":"MC13TeV_ZJetsToNuNu_HT-600To800_2016", "xsec":0.853, "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-600To800_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
-        { "dtag":"MC13TeV_ZJetsToNuNu_HT-800To1200_2016", "xsec":0.3942, "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-800To1200_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v3/MINIAODSIM"]},
-        { "dtag":"MC13TeV_ZJetsToNuNu_HT-1200To2500_2016", "xsec":0.0974, "br":[ 0.5 ], "dset":["/ZJetsToNuNu_HT-1200To2500_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
-        { "dtag":"MC13TeV_ZJetsToNuNu_HT-1200To2500_ext1_2016", "xsec":0.0974, "br":[ 0.5 ], "dset":["/ZJetsToNuNu_HT-1200To2500_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
-        { "dtag":"MC13TeV_ZJetsToNuNu_HT-2500ToInf_2016", "xsec":0.002308, "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-2500ToInf_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-100To200_2016", "xsec":280.35,  "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-100To200_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-200To400_2016", "xsec":77.67 , "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-200To400_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-400To600_2016", "xsec":10.73, "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-400To600_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-600To800_2016", "xsec":3.221, "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-600To800_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-800To1200_2016", "xsec":1.474 , "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-800To1200_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v3/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-1200To2500_2016", "xsec":0.3586 , "br":[ 0.5 ], "dset":["/ZJetsToNuNu_HT-1200To2500_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-1200To2500_ext1_2016", "xsec":0.3586 , "br":[ 0.5 ], "dset":["/ZJetsToNuNu_HT-1200To2500_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-2500ToInf_2016", "xsec":0.008203 , "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-2500ToInf_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
       ]
     },  
+    {
+    "tag":"Top+#gamma",
+    "keys":["2l2v_2016", "2l2v_photoncontrol", "2l2v_photonsOnly"],                                                                                    
+      "isdata":false,
+      "color":623,                     
+      "2l2v_photonsOnly":{"suffix":"reweighted"}, 
+      "data":[ 
+      { "dtag":"MC13TeV_TTGJets_2016", "xsec":3.697, "br":[ 1.0 ], "dset":["/TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISpring16DR80-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/AODSIM"]},
+       { "dtag":"MC13TeV_TGJets_2016", "xsec":2.967, "br":[ 0.25 ], "dset":["/TGJets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+       { "dtag":"MC13TeV_TGJets_ext1_2016", "xsec":2.967, "br":[ 0.75 ], "dset":["/TGJets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]}
+      ]	
+     },
      {
       "tag":"Z#gamma #rightarrow ll#gamma",                                                                                   
       "keys":["2l2v_2016", "2l2v_photoncontrol", "2l2v_photonsOnly"],      
@@ -171,6 +256,17 @@
 	{ "dtag":"MC13TeV_ZGToLNuGi_ext1_2016", "xsec":117.864, "br":[ 0.75 ], "dset":["/ZGTo2LG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]}
       ]
     },
+     {                                                                                                                                                                
+        "tag":"Z#gamma #rightarrow #nu#nu#gamma", 
+        "keys":["2l2v_2016","2l2v_photoncontrol", "2l2v_photonsOnly"], 
+        "isdata":false, 
+        "color":800, 
+        "2l2v_photonsOnly":{"suffix":"reweighted"}, 
+	"data":[ 
+        { "dtag":"MC13TeV_ZGToNuNuGi_2016", "xsec":117.864, "br":[ 0.25 ], "dset":["/ZGTo2LG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},                
+        { "dtag":"MC13TeV_ZGToNuNuGi_ext1_2016", "xsec":117.864, "br":[ 0.75 ], "dset":["/ZGTo2LG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]}
+      ]  
+    },  
     {
       "tag":"W#gamma #rightarrow l#nu#gamma",
       "keys":["2l2v_2016", "2l2v_photoncontrol", "2l2v_photonsOnly"],      
@@ -181,23 +277,24 @@
         { "dtag":"MC13TeV_WGToLNuG_2016" , "xsec":405.271, "br":[ 1.0 ] , "dset":["/WGToLNuG_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
       ]
     },
-        {
+    {
       "tag":"QCD, HT>100",
       "keys":["2l2v_2016", "2l2v_photoncontrol"],      
       "isdata":false,
       "color":21,
       "data":[
-        { "dtag":"MC13TeV_QCD_HT200to300_2016"  , "xsec":1717000  , "br":[ 1.0 ],        "dset":["/QCD_HT200to300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
-        { "dtag":"MC13TeV_QCD_HT300to500_2016"  , "xsec":351300   , "br":[ 0.5 ],	    "dset":["/QCD_HT1000to1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v2/MINIAODSIM"]},
-        { "dtag":"MC13TeV_QCD_HT300to500_ext1_2016"  , "xsec":351300   , "br":[ 0.5 ],	    "dset":["/QCD_HT300to500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
-        { "dtag":"MC13TeV_QCD_HT500to700_2016"  , "xsec":31630    , "br":[ 1.0 ],	    "dset":["/QCD_HT500to700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
-        { "dtag":"MC13TeV_QCD_HT700to1000_2016" , "xsec":6802     , "br":[ 0.5 ],	    "dset":["/QCD_HT700to1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
-        { "dtag":"MC13TeV_QCD_HT700to1000_ext1_2016" , "xsec":6802     , "br":[ 0.5 ],	    "dset":["/QCD_HT700to1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
-        { "dtag":"MC13TeV_QCD_HT1000to1500_2016", "xsec":1206     , "br":[ 0.5 ],	    "dset":["/QCD_HT1000to1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v2/MINIAODSIM"]},
-        { "dtag":"MC13TeV_QCD_HT1000to1500_ext1_2016", "xsec":1206     , "br":[ 0.5 ],	    "dset":["/QCD_HT1000to1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
-        { "dtag":"MC13TeV_QCD_HT1500to2000_2016", "xsec":120.4    , "br":[ 0.5 ],	    "dset":["/QCD_HT1500to2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v3/MINIAODSIM"]},
-        { "dtag":"MC13TeV_QCD_HT1500to2000_ext1_2016", "xsec":120.4    , "br":[ 0.5 ],	    "dset":["/QCD_HT1500to2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
-       	{ "dtag":"MC13TeV_QCD_HT2000toInf_2016" , "xsec":25.24    , "br":[ 0.5 ],      "dset":["/QCD_HT2000toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_QCD_HT100to200_2016"  , "xsec":27990000 , "br":[ 1.0 ],    "dset":["/QCD_HT100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},	
+        { "dtag":"MC13TeV_QCD_HT200to300_2016"  , "xsec":1712000  , "br":[ 1.0 ],    "dset":["/QCD_HT200to300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT300to500_2016"  , "xsec":347700   , "br":[ 0.5 ],	    "dset":["/QCD_HT300to500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT300to500_ext1_2016"  , "xsec":347700  , "br":[ 0.5 ],	    "dset":["/QCD_HT300to500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT500to700_2016"  , "xsec":32100  , "br":[ 1.0 ],	    "dset":["/QCD_HT500to700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT700to1000_2016" , "xsec":6831    , "br":[ 0.5 ],	    "dset":["/QCD_HT700to1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT700to1000_ext1_2016" , "xsec":6831     , "br":[ 0.5 ],	    "dset":["/QCD_HT700to1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT1000to1500_2016", "xsec":1207     , "br":[ 0.5 ],	    "dset":["/QCD_HT1000to1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v2/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT1000to1500_ext1_2016", "xsec":1207     , "br":[ 0.5 ],	    "dset":["/QCD_HT1000to1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT1500to2000_2016", "xsec":119.9    , "br":[ 0.5 ],	    "dset":["/QCD_HT1500to2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v3/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT1500to2000_ext1_2016", "xsec":119.9    , "br":[ 0.5 ],	    "dset":["/QCD_HT1500to2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+       	{ "dtag":"MC13TeV_QCD_HT2000toInf_2016" , "xsec":25.24     , "br":[ 0.5 ],      "dset":["/QCD_HT2000toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
        	{ "dtag":"MC13TeV_QCD_HT2000toInf_ext1_2016" , "xsec":25.24    , "br":[ 0.5 ],      "dset":["/QCD_HT2000toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]} 
       ]
     },
@@ -209,13 +306,13 @@
       "data":[
         { "dtag":"MC13TeV_QCD_Pt20To30_EMEnr_2016"     ,  "xsec":557600000     , "br":[ 0.0096 ]        ,	"dset":["/QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
         { "dtag":"MC13TeV_QCD_Pt30To50_EMEnr_2016"     ,  "xsec":136000000     , "br":[ 0.0365 ]         , 	"dset":["/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
-        { "dtag":"MC13TeV_QCD_Pt30To50_EMEnr_ext1_2016"     ,  "xsec":136000000     , "br":[ 0.0365 ]         , 	"dset":["/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_Pt30To50_EMEnr_ext1_2016"     ,  "xsec":136000000     , "br":[ 0.0365 ]         , "dset":["/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
         { "dtag":"MC13TeV_QCD_Pt50To80_EMEnr_2016"     ,  "xsec":19800000      , "br":[ 0.146 ]         , 	"dset":["/QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
         { "dtag":"MC13TeV_QCD_Pt80To120_EMEnr_2016"    ,  "xsec":2800000       , "br":[ 0.125 ]         , 	"dset":["/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
         { "dtag":"MC13TeV_QCD_Pt120To170_EMEnr_2016"   ,  "xsec":477000        , "br":[ 0.132 ]         , 	"dset":["/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
         { "dtag":"MC13TeV_QCD_Pt170To300_EMEnr_2016"   ,  "xsec":114000        , "br":[ 0.165 ]         , 	"dset":["/QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
         { "dtag":"MC13TeV_QCD_Pt300ToInf_EMEnr_2016"   ,  "xsec":9000          , "br":[ 0.15 ]          , 	"dset":["/QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
-        { "dtag":"MC13TeV_QCD_Pt20ToInf_MEnr_2016"   ,  "xsec":720648000       , "br":[ 0.00042 ]       ,	"dset":["/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]} 
+        { "dtag":"MC13TeV_QCD_Pt20ToInf_MuEnr_2016"   ,  "xsec":720648000       , "br":[ 0.00042 ]       ,	"dset":["/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]} 
       ]	
     },	   
      {
@@ -263,7 +360,7 @@
       "isinvisible":true,      
       "isdata":false,
       "color":41,
-	"mixing":[{"tag":"W#gamma #rightarrow l#nu#gamma_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow ll#gamma_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #nu#nu_reweighted", "scale":1.0}, {"tag":"W#rightarrow l#nu_reweighted", "scale":1.0}, {"tag":"Top_reweighted", "scale":1.0},  {"tag":"WZ_reweighted", "scale":1.0},  {"tag":"WW_reweighted", "scale":1.0} ]
+	"mixing":[{"tag":"W#gamma #rightarrow l#nu#gamma_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow ll#gamma_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #nu#nu_reweighted", "scale":1.0}, {"tag":"W#rightarrow l#nu, HT>100_reweighted", "scale":1.0}, {"tag":"Top_reweighted", "scale":1.0},  {"tag":"WZ_reweighted", "scale":1.0},  {"tag":"WW_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #tau#tau_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow #nu#nu#gamma_reweighted", "scale":1.0}, {"tag":"Top+#gamma_reweighted", "scale":1.0} ]
     },
     {
       "tag":"Genuine (ewk) MET",

--- a/test/hzz2l2v/samples2016.json
+++ b/test/hzz2l2v/samples2016.json
@@ -39,11 +39,10 @@
     },
     {
       "tag":"ZZ",
-      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_photoncontrol", "2l2v_photonsOnly", "2l2v_datadriven_SM", "2l2v_datadriven_RsGrav", "2l2v_datadriven_BulkGrav", "2l2v_datadriven_Rad", "2l2v_mcbased_SM", "2l2v_mcbased_RsGrav", "2l2v_mcbased_BulkGrav", "2l2v_mcbased_Rad"],
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_photoncontrol", "2l2v_datadriven_SM", "2l2v_datadriven_RsGrav", "2l2v_datadriven_BulkGrav", "2l2v_datadriven_Rad", "2l2v_mcbased_SM", "2l2v_mcbased_RsGrav", "2l2v_mcbased_BulkGrav", "2l2v_mcbased_Rad"],
       "isdata":false,
       "color":592,
-      "mctruthmode":1113,
-      "2l2v_photonsOnly":{"suffix":"reweighted"},         
+      "mctruthmode":1113,         
       "data":[
         { "dtag":"MC13TeV_ZZ2l2q_2016"                          ,  "xsec":3.22             , "br":[ 1.0 ]           , "dset":["/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
         { "dtag":"MC13TeV_ZZ2l2nu_2016"                         ,  "xsec":0.564            , "br":[ 1.0 ]           , "dset":["/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
@@ -263,8 +262,8 @@
         "color":800, 
         "2l2v_photonsOnly":{"suffix":"reweighted"}, 
 	"data":[ 
-        { "dtag":"MC13TeV_ZGToNuNuGi_2016", "xsec":117.864, "br":[ 0.25 ], "dset":["/ZGTo2LG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},                
-        { "dtag":"MC13TeV_ZGToNuNuGi_ext1_2016", "xsec":117.864, "br":[ 0.75 ], "dset":["/ZGTo2LG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]}
+	{ "dtag":"MC13TeV_ZNuNuGJets_PtG-40to130_2016", "xsec":2.816  , "br":[ 1.0 ], "dset":["/ZNuNuGJets_MonoPhoton_PtG-40to130_TuneCUETP8M1_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},	 
+	{ "dtag":"MC13TeV_ZNuNuGJets_PtG-130_2016", "xsec":0.223  , "br":[ 1.0 ], "dset":["/ZNuNuGJets_MonoPhoton_PtG-130_TuneCUETP8M1_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
       ]  
     },  
     {


### PR DESCRIPTION
o added missing Z(->nunu)+g samples, and T+g, TT+g as well
o updated Z->nunu (in HTbinned) xsections
o now W+jets,HT>100 runs only in photon CR -- W+jets inclusive in SR
o instr. MET obtained by subtracting also the EWK samples: Z(->nunu)+g, Z->tautau, Top/WZ/WW, Top+g
o added missing QCD bin HT100to200 sample