### PR TITLE
residual fixes and updates

### DIFF
--- a/src/GammaWeightsHandler.cc
+++ b/src/GammaWeightsHandler.cc
@@ -13,7 +13,7 @@ GammaWeightsHandler::GammaWeightsHandler(const edm::ParameterSet &runProcess,TSt
   std::vector<TString> wgtNames; 
   wgtNames.push_back("qt");
   if(ewkSupWgt!="") wgtNames.push_back(ewkSupWgt);
-  TString wgtType( isMC ? "mcfitwgts" : "datafitfunctionwgts_norm"); //datafitwgtsrebin if ypu use bins, datafitfunctionwgts_norm if you use fitting functions
+  TString wgtType( isMC ? "mcfitwgts" : "datafitwgtsrebin"); //datafitwgtsrebin if ypu use bins, datafitfunctionwgts_norm if you use fitting functions
   TString massType( isMC ? "mczmass" : "zmass");
     
   //categories to consider, add more if needed but keep these ones 

--- a/test/hzz2l2v/samples2016.json
+++ b/test/hzz2l2v/samples2016.json
@@ -2,7 +2,7 @@
   "proc":[
     {
       "tag":"data",
-      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_datadriven_RsGrav", "2l2v_datadriven_BulkGrav", "2l2v_datadriven_Rad", "2l2v_mcbased_SM", "2l2v_mcbased_RsGrav", "2l2v_mcbased_BulkGrav", "2l2v_mcbased_Rad"],
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_datadriven_RsGrav", "2l2v_datadriven_BulkGrav", "2l2v_datadriven_Rad", "2l2v_mcbased_SM", "2l2v_mcbased_RsGrav", "2l2v_mcbased_BulkGrav", "2l2v_mcbased_Rad","genuineMet"],
       "isdata":true,
       "color":1,
       "fill":0,
@@ -131,16 +131,6 @@
       { "dtag":"MC13TeV_WJets_HT-2500ToInf_2016"                            ,  "xsec":0.03216       , "br":[ 1.0 ]                 , "dset":["/WJetsToLNu_HT-2500ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
       ]
      },
-      {
-     "tag":"W#rightarrow qq, HT>600",
-      "keys":["2l2v_2016", "2l2v_photoncontrol","2l2v_photonsOnly"],           
-      "isdata":false,
-      "color":810,
-      "2l2v_photonsOnly":{"suffix":"reweighted"},
-      "data":[
-	  { "dtag":"MC13TeV_WJetsToQQ_HT-600ToInf_2016",  "xsec":95.14        , "br":[ 1.0 ]   , "dset":["/WJetsToQQ_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
-      ]
-      },
      {
       "tag":"Z#rightarrow #tau#tau",
       "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_photoncontrol","2l2v_photonsOnly", "2l2v_mcbased_SM", "2l2v_mcbased_RsGrav", "2l2v_mcbased_BulkGrav", "2l2v_mcbased_Rad","2l2v_datadriven", "2l2v_datadriven_SM", "2l2v_datadriven_RsGrav", "2l2v_datadriven_BulkGrav", "2l2v_datadriven_Rad"],      
@@ -316,10 +306,10 @@
     },	   
      {
       "tag":"#gamma+jets",
-      "keys":["2l2v_2016", "2l2v_photoncontrol","2l2v_photonsOnly"],           
+      "keys":["2l2v_2016", "2l2v_photoncontrol","2l2v_mcphotonsOnly"],           
       "isdata":false,
       "color":390,
-      "2l2v_photonsOnly":{"suffix":"reweighted"},
+      "2l2v_mcphotonsOnly":{"suffix":"reweighted"},
       "data":[                                                                     
         { "dtag":"MC13TeV_GJet_HT-40to100_2016"                  ,  "xsec":20730.0, "br":[ 1.0 ],      "dset":["/GJets_HT-40To100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
         { "dtag":"MC13TeV_GJet_HT-100to200_2016"                 ,  "xsec":9226.0 , "br":[ 1.0 ],      "dset":["/GJets_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v4/MINIAODSIM"]},
@@ -330,7 +320,7 @@
     }, 
     {
       "tag":"#gamma data",
-      "keys":["2l2v_2016", "2l2v_photoncontrol", "2l2v_photonsOnly", "genuineMet"],
+      "keys":["2l2v_2016", "2l2v_photoncontrol", "2l2v_photonsOnly"],
       "isdata":true,
       "color":1,
       "fill":0,

--- a/test/hzz2l2v/samples_ichep2016.json
+++ b/test/hzz2l2v/samples_ichep2016.json
@@ -1,0 +1,884 @@
+{
+  "proc":[
+    {
+      "tag":"data",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM",  "2l2v_datadriven_Rad", "2l2v_mcbased_SM",  "2l2v_mcbased_Rad","genuineMet"],
+      "isdata":true,
+      "color":1,
+      "fill":0,
+      "marker":20,
+      "msize":0.7,
+      "data":[ 
+          { "dtag":"Data13TeV_MuEG2016B"                 ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/MuonEG/Run2016B-PromptReco-v2/MINIAOD"]           ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   },
+	  { "dtag":"Data13TeV_MuEG2016C"                 ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/MuonEG/Run2016C-PromptReco-v2/MINIAOD"]           ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   },
+	  { "dtag":"Data13TeV_MuEG2016D"                 ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/MuonEG/Run2016D-PromptReco-v2/MINIAOD"]           ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   },
+          { "dtag":"Data13TeV_SingleElectron2016B"       ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/SingleElectron/Run2016B-PromptReco-v2/MINIAOD"]   ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   },
+	  { "dtag":"Data13TeV_SingleElectron2016C"       ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/SingleElectron/Run2016C-PromptReco-v2/MINIAOD"]   ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   },
+	   { "dtag":"Data13TeV_SingleElectron2016D"       ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/SingleElectron/Run2016D-PromptReco-v2/MINIAOD"]   ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   },
+          { "dtag":"Data13TeV_SingleMu2016B"             ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/SingleMuon/Run2016B-PromptReco-v2/MINIAOD"]       ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   },
+	  { "dtag":"Data13TeV_SingleMu2016C"             ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/SingleMuon/Run2016C-PromptReco-v2/MINIAOD"]       ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   },
+	  { "dtag":"Data13TeV_SingleMu2016D"             ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/SingleMuon/Run2016D-PromptReco-v2/MINIAOD"]       ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   },
+          { "dtag":"Data13TeV_DoubleMu2016B"             ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/DoubleMuon/Run2016B-PromptReco-v2/MINIAOD"]       ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   },
+	  { "dtag":"Data13TeV_DoubleMu2016C"             ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/DoubleMuon/Run2016C-PromptReco-v2/MINIAOD"]       ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   },
+	  { "dtag":"Data13TeV_DoubleMu2016D"             ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/DoubleMuon/Run2016D-PromptReco-v2/MINIAOD"]       ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   },
+          { "dtag":"Data13TeV_DoubleElectron2016B"       ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/DoubleEG/Run2016B-PromptReco-v2/MINIAOD"]         ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   },
+	  { "dtag":"Data13TeV_DoubleElectron2016C"       ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/DoubleEG/Run2016C-PromptReco-v2/MINIAOD"]         ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   },
+	  { "dtag":"Data13TeV_DoubleElectron2016D"       ,  "xsec":1.0         , "br":[ 1.0 ]      , "dset":["/DoubleEG/Run2016D-PromptReco-v2/MINIAOD"]         ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt"   }
+      ]
+    },
+    {
+      "tag":"ZZ#rightarrow Z#tau#tau",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_photoncontrol", "2l2v_datadriven_SM",  "2l2v_datadriven_Rad", "2l2v_mcbased_SM",  "2l2v_mcbased_Rad"],
+      "isdata":false,
+      "color":595,
+      "mctruthmode":15,         
+      "data":[
+        { "dtag":"MC13TeV_ZZ2l2q_2016"                          ,  "xsec":3.22             , "br":[ 1.0 ]           , "dset":["/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZZ2l2nu_2016"                         ,  "xsec":0.564            , "br":[ 1.0 ]           , "dset":["/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+      ]
+    },
+    {
+      "tag":"ZZ",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_photoncontrol", "2l2v_datadriven_SM",  "2l2v_datadriven_Rad", "2l2v_mcbased_SM",  "2l2v_mcbased_Rad"],
+      "isdata":false,
+      "color":592,
+      "mctruthmode":1113,         
+      "data":[
+        { "dtag":"MC13TeV_ZZ2l2q_2016"                          ,  "xsec":3.22             , "br":[ 1.0 ]           , "dset":["/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZZ2l2nu_2016"                         ,  "xsec":0.564            , "br":[ 1.0 ]           , "dset":["/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ggZZ2mu2nu_2016"                      ,  "xsec":0.01898          , "br":[ 1.0 ]           , "dset":["/GluGluToContinToZZTo2mu2nu_13TeV_MCFM701_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}, 
+        { "dtag":"MC13TeV_ggZZ2e2nu_2016"                       ,  "xsec":0.01898          , "br":[ 1.0 ]           , "dset":["/GluGluToContinToZZTo2e2nu_13TeV_MCFM701_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+      ]
+    },
+    {
+      "tag":"WW",
+	"keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_photoncontrol", "2l2v_photonsOnly", "2l2v_datadriven_SM",  "2l2v_datadriven_Rad", "2l2v_mcbased_SM",  "2l2v_mcbased_Rad"],
+      "isdata":false,
+	"color":590,
+	"2l2v_photonsOnly":{"suffix":"reweighted"},
+      "data":[
+        { "dtag":"MC13TeV_WW2l2nu_2016"                      ,  "xsec":12.178       , "br":[ 1 ]           , "dset":["/WWTo2L2Nu_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_WWlnu2q_2016"                      ,  "xsec":49.997      , "br":[ 0.5 ]           , "dset":["/WWToLNuQQ_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_WWlnu2q_ext1_2016"                 ,  "xsec":49.997      , "br":[ 0.5 ]           , "dset":["/WWToLNuQQ_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]}
+      ]
+    },
+    { 
+      "tag":"WZ",
+	"keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_photoncontrol", "2l2v_photonsOnly", "2l2v_datadriven_SM",  "2l2v_datadriven_Rad", "2l2v_mcbased_SM",  "2l2v_mcbased_Rad"],      
+      "isdata":false,
+	"color":594,
+	"2l2v_photonsOnly":{"suffix":"reweighted"},
+      "data":[
+        { "dtag":"MC13TeV_WZ3lnu_2016"                      ,  "xsec":4.42965     , "br":[ 1 ]           , "dset":["/WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_WZ2l2q_2016"                      ,  "xsec":5.595       , "br":[ 1 ]           , "dset":["/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+      ]
+    }, 
+    { 
+      "tag":"ZVV",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_photoncontrol", "2l2v_datadriven_SM",  "2l2v_datadriven_Rad", "2l2v_mcbased_SM",  "2l2v_mcbased_Rad"],
+      "isdata":false,
+      "color":869,
+      "data":[
+        { "dtag":"MC13TeV_ZZZ_2016"            ,  "xsec":0.01398       , "br":[ 1 ]    , "dset":["/ZZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_WZZ_2016"            ,  "xsec":0.05565       , "br":[ 1 ]    , "dset":["/WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_WWZ_2016"            ,  "xsec":0.16510       , "br":[ 1 ]    , "dset":["/WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+      ]
+    },
+    {
+      "tag":"Top",
+	"keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_photoncontrol",  "2l2v_photonsOnly", "2l2v_datadriven_SM",  "2l2v_datadriven_Rad", "2l2v_mcbased_SM",  "2l2v_mcbased_Rad"],
+      "isdata":false,
+	"color":8,
+	"2l2v_photonsOnly":{"suffix":"reweighted"},
+      "data":[
+        { "dtag":"MC13TeV_TT2l2nu_ext1_2016"                      ,  "xsec":87.31      , "br":[ 1.0 ] , "dset":["/TTTo2L2Nu_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]}, 
+        { "dtag":"MC13TeV_SingleT_s_2016"                         ,  "xsec":3.362      , "br":[ 1.0 ] , "dset":["/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_SingleT_t_2016"                         ,  "xsec":70.69      , "br":[ 1.0 ] , "dset":["/ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_SingleT_atW_2016"                       ,  "xsec":35.6       , "br":[ 1 ] , "dset":["/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_SingleT_tW_2016"                        ,  "xsec":35.6       , "br":[ 1 ] , "dset":["/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v2/MINIAODSIM"]},
+        { "dtag":"MC13TeV_TTWJetslnu_2016"                        ,  "xsec":2.043e-01  , "br":[ 1 ] , "dset":["/TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_TTZJets2l2nu_2016"                      ,  "xsec":2.529e-01  , "br":[ 1 ] , "dset":["/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+      ]
+    },
+    {
+       "tag":"W#rightarrow l#nu",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_mcbased_SM",  "2l2v_mcbased_Rad", "2l2v_datadriven", "2l2v_datadriven_SM",  "2l2v_datadriven_Rad"],
+     "isdata":false,
+      "color":809, 
+      "data":[ 
+        { "dtag":"MC13TeV_WJets_2016"                            ,  "xsec":61526.7       , "br":[ 0.15 ]  , "dset":["/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_WJets_ext1_2016"                            ,  "xsec":61526.7       , "br":[ 0.85 ]  , "dset":["/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]}
+      ]
+    },
+     {
+     "tag":"W#rightarrow l#nu, HT>100",
+      "keys":["2l2v_2016", "2l2v_photoncontrol","2l2v_photonsOnly"],
+      "isdata":false,
+      "color":809,
+      "2l2v_photonsOnly":{"suffix":"reweighted"},
+      "data":[
+      { "dtag":"MC13TeV_WJets_HT-100To200_ext1_2016"                            ,  "xsec":1345        , "br":[ 1.0 ]                 , "dset":["/WJetsToLNu_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+      { "dtag":"MC13TeV_WJets_HT-200To400_2016"                            ,  "xsec":359.7       , "br":[ 0.5 ]                 , "dset":["/WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+      { "dtag":"MC13TeV_WJets_HT-200To400_ext1_2016"                            ,  "xsec":359.7       , "br":[ 0.5 ]                 , "dset":["/WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+      { "dtag":"MC13TeV_WJets_HT-400To600_2016"                            ,  "xsec":48.91       , "br":[ 0.5 ]                 , "dset":["/WJetsToLNu_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+      { "dtag":"MC13TeV_WJets_HT-400To600_ext1_2016"                            ,  "xsec":48.91       , "br":[ 0.5 ]                 , "dset":["/WJetsToLNu_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},	
+      { "dtag":"MC13TeV_WJets_HT-600To800_2016"                            ,  "xsec":12.05        , "br":[ 0.5 ]                 , "dset":["/WJetsToLNu_HT-600To800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+      { "dtag":"MC13TeV_WJets_HT-600To800_ext1_2016"                            ,  "xsec":12.05        , "br":[ 0.5 ]                 , "dset":["/WJetsToLNu_HT-600To800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+      { "dtag":"MC13TeV_WJets_HT-800To1200_2016"                            ,  "xsec":5.501       , "br":[ 0.5 ]                 , "dset":["/WJetsToLNu_HT-800To1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v2/MINIAODSIM"]},
+      { "dtag":"MC13TeV_WJets_HT-800To1200_ext1_2016"                            ,  "xsec":5.501       , "br":[ 0.5 ]                 , "dset":["/WJetsToLNu_HT-800To1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+      { "dtag":"MC13TeV_WJets_HT-1200To2500_2016"                            ,  "xsec":1.329       , "br":[ 0.5 ]                 , "dset":["/WJetsToLNu_HT-1200To2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+      { "dtag":"MC13TeV_WJets_HT-1200To2500_ext1_2016"                            ,  "xsec":1.329       , "br":[ 0.5 ]                 , "dset":["/WJetsToLNu_HT-1200To2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+      { "dtag":"MC13TeV_WJets_HT-2500ToInf_2016"                            ,  "xsec":0.03216       , "br":[ 1.0 ]                 , "dset":["/WJetsToLNu_HT-2500ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+      ]
+     },
+     {
+      "tag":"Z#rightarrow #tau#tau",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_photoncontrol","2l2v_photonsOnly", "2l2v_mcbased_SM",  "2l2v_mcbased_Rad","2l2v_datadriven", "2l2v_datadriven_SM",  "2l2v_datadriven_Rad"],      
+      "mctruthmode":15,    
+      "isdata":false,
+      "color":833,
+      "2l2v_photonsOnly":{"suffix":"reweighted"},
+      "data":[
+        { "dtag":"MC13TeV_DYJetsToLL_10to50_2016"               ,  "xsec":18610     , "br":[ 1.0 ]    , "dset":["/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_DYJetsToLL_50toInf_2016"              ,  "xsec":5765.4    , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+      ]
+     },
+      {
+      "tag":"Z#rightarrow #tau#tau, HT>100",
+      "keys":["2l2v_2016"],
+      "mctruthmode":15,    
+      "isdata":false,
+      "color":834,
+	  "data":[
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-100To200_2016"               ,  "xsec":224.2 , "br":[ 1.0 ]   , "dset":["/DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-200To400_2016"               ,  "xsec":37.2 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-200To400_ext1_2016"               ,  "xsec":37.2 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-400To600_2016"               ,  "xsec":3.581 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-400To600_ext1_2016"               ,  "xsec":3.581 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-600ToInf_2016"               ,  "xsec":1.124 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-600ToInf_ext1_2016"               ,  "xsec":1.124 , "br":[ 0.5 ]   , "dset":[" /DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-100To200_2016"              ,  "xsec":147.40    , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-100To200_ext1_2016"              ,  "xsec":147.40    , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-200To400_2016"              ,  "xsec":40.99     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-200To400_ext1_2016"              ,  "xsec":40.99     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]}, 				 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-400To600_2016"              ,  "xsec":5.678     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-400To600_ext1_2016"              ,  "xsec":5.678     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-600To800_2016"              ,  "xsec":1.367     , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-600to800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-800To1200_2016"              ,  "xsec":0.6304      , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-800to1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-1200To2500_2016"              ,  "xsec":0.1514       , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-1200to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-2500ToInf_2016"              ,  "xsec":0.003565       , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-2500toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+	]
+     },
+    {
+      "tag":"Z#rightarrow ee/#mu#mu",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_photoncontrol","2l2v_photonsOnly","2l2v_mcbased_SM",  "2l2v_mcbased_Rad"],
+      "isdata":false,
+      "mctruthmode":1113,    
+      "color":831,
+      "2l2v_photonsOnly":{"suffix":"reweighted"},  
+      "data":[
+        { "dtag":"MC13TeV_DYJetsToLL_10to50_2016"               ,  "xsec":18610     , "br":[ 1.0 ]   , "dset":["/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_DYJetsToLL_50toInf_2016"              ,  "xsec":5765.4    , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+      ]
+    },
+   {
+      "tag":"Z#rightarrow ee/#mu#mu, HT>100",
+       "keys":["2l2v_2016"],
+      "isdata":false,
+      "mctruthmode":1113,    
+      "color":832,
+       "data":[
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-100To200_2016"               ,  "xsec":224.2 , "br":[ 1.0 ]   , "dset":["/DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-200To400_2016"               ,  "xsec":37.2 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-200To400_ext1_2016"               ,  "xsec":37.2 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-400To600_2016"               ,  "xsec":3.581 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-400To600_ext1_2016"               ,  "xsec":3.581 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-600ToInf_2016"               ,  "xsec":1.124 , "br":[ 0.5 ]   , "dset":["/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	  { "dtag":"MC13TeV_DYJetsToLL_5to50_HT-600ToInf_ext1_2016"               ,  "xsec":1.124 , "br":[ 0.5 ]   , "dset":[" /DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-100To200_2016"              ,  "xsec":147.40    , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-100To200_ext1_2016"              ,  "xsec":147.40    , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-200To400_2016"              ,  "xsec":40.99     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-200To400_ext1_2016"              ,  "xsec":40.99     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]}, 				 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-400To600_2016"              ,  "xsec":5.678     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-400To600_ext1_2016"              ,  "xsec":5.678     , "br":[ 0.5 ]        , "dset":["/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-600To800_2016"              ,  "xsec":1.367     , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-600to800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	 { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-800To1200_2016"              ,  "xsec":0.6304      , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-800to1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-1200To2500_2016"              ,  "xsec":0.1514       , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-1200to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	   { "dtag":"MC13TeV_DYJetsToLL_50toInf_HT-2500ToInf_2016"              ,  "xsec":0.003565       , "br":[ 1.0 ]        , "dset":["/DYJetsToLL_M-50_HT-2500toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+	]
+    },																			  
+    {
+      "tag":"Z#rightarrow #nu#nu",
+      "keys":["2l2v_2016", "2l2v_photoncontrol", "2l2v_photonsOnly"],      
+      "isdata":false,                                                                         
+      "color":7,
+      "2l2v_photonsOnly":{"suffix":"reweighted"},	
+      "data":[                                                                                             
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-100To200_2016", "xsec":280.35,  "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-100To200_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-200To400_2016", "xsec":77.67 , "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-200To400_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-400To600_2016", "xsec":10.73, "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-400To600_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-600To800_2016", "xsec":3.221, "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-600To800_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-800To1200_2016", "xsec":1.474 , "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-800To1200_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v3/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-1200To2500_2016", "xsec":0.3586 , "br":[ 0.5 ], "dset":["/ZJetsToNuNu_HT-1200To2500_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-1200To2500_ext1_2016", "xsec":0.3586 , "br":[ 0.5 ], "dset":["/ZJetsToNuNu_HT-1200To2500_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_ZJetsToNuNu_HT-2500ToInf_2016", "xsec":0.008203 , "br":[ 1.0 ], "dset":["/ZJetsToNuNu_HT-2500ToInf_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+      ]
+    },  
+    {
+    "tag":"Top+#gamma",
+    "keys":["2l2v_2016", "2l2v_photoncontrol", "2l2v_photonsOnly"],                                                                                    
+      "isdata":false,
+      "color":623,                     
+      "2l2v_photonsOnly":{"suffix":"reweighted"}, 
+      "data":[ 
+      { "dtag":"MC13TeV_TTGJets_2016", "xsec":3.697, "br":[ 1.0 ], "dset":["/TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISpring16DR80-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/AODSIM"]},
+       { "dtag":"MC13TeV_TGJets_2016", "xsec":2.967, "br":[ 0.25 ], "dset":["/TGJets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+       { "dtag":"MC13TeV_TGJets_ext1_2016", "xsec":2.967, "br":[ 0.75 ], "dset":["/TGJets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]}
+      ]	
+     },
+     {
+      "tag":"Z#gamma #rightarrow ll#gamma",                                                                                   
+      "keys":["2l2v_2016", "2l2v_photoncontrol", "2l2v_photonsOnly"],      
+      "isdata":false,                                                                                                           
+      "color":635,                            
+      "2l2v_photonsOnly":{"suffix":"reweighted"},                                                                                  
+      "data":[  
+        { "dtag":"MC13TeV_ZGToLNuGi_2016", "xsec":117.864, "br":[ 0.25 ], "dset":["/ZGTo2LG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+	{ "dtag":"MC13TeV_ZGToLNuGi_ext1_2016", "xsec":117.864, "br":[ 0.75 ], "dset":["/ZGTo2LG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]}
+      ]
+    },
+     {                                                                                                                                                                
+        "tag":"Z#gamma #rightarrow #nu#nu#gamma", 
+        "keys":["2l2v_2016","2l2v_photoncontrol", "2l2v_photonsOnly"], 
+        "isdata":false, 
+        "color":800, 
+        "2l2v_photonsOnly":{"suffix":"reweighted"}, 
+	"data":[ 
+	{ "dtag":"MC13TeV_ZNuNuGJets_PtG-40to130_2016", "xsec":2.816  , "br":[ 1.0 ], "dset":["/ZNuNuGJets_MonoPhoton_PtG-40to130_TuneCUETP8M1_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},	 
+	{ "dtag":"MC13TeV_ZNuNuGJets_PtG-130_2016", "xsec":0.223  , "br":[ 1.0 ], "dset":["/ZNuNuGJets_MonoPhoton_PtG-130_TuneCUETP8M1_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+      ]  
+    },  
+    {
+      "tag":"W#gamma #rightarrow l#nu#gamma",
+      "keys":["2l2v_2016", "2l2v_photoncontrol", "2l2v_photonsOnly"],      
+      "isdata":false,
+      "color":52,
+      "2l2v_photonsOnly":{"suffix":"reweighted"},	
+      "data":[
+        { "dtag":"MC13TeV_WGToLNuG_2016" , "xsec":405.271, "br":[ 1.0 ] , "dset":["/WGToLNuG_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+      ]
+    },
+    {
+      "tag":"QCD, HT>100",
+      "keys":["2l2v_2016", "2l2v_photoncontrol"],      
+      "isdata":false,
+      "color":21,
+      "data":[
+	{ "dtag":"MC13TeV_QCD_HT100to200_2016"  , "xsec":27990000 , "br":[ 1.0 ],    "dset":["/QCD_HT100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},	
+        { "dtag":"MC13TeV_QCD_HT200to300_2016"  , "xsec":1712000  , "br":[ 1.0 ],    "dset":["/QCD_HT200to300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT300to500_2016"  , "xsec":347700   , "br":[ 0.5 ],	    "dset":["/QCD_HT300to500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT300to500_ext1_2016"  , "xsec":347700  , "br":[ 0.5 ],	    "dset":["/QCD_HT300to500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT500to700_2016"  , "xsec":32100  , "br":[ 1.0 ],	    "dset":["/QCD_HT500to700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT700to1000_2016" , "xsec":6831    , "br":[ 0.5 ],	    "dset":["/QCD_HT700to1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT700to1000_ext1_2016" , "xsec":6831     , "br":[ 0.5 ],	    "dset":["/QCD_HT700to1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT1000to1500_2016", "xsec":1207     , "br":[ 0.5 ],	    "dset":["/QCD_HT1000to1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v2/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT1000to1500_ext1_2016", "xsec":1207     , "br":[ 0.5 ],	    "dset":["/QCD_HT1000to1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT1500to2000_2016", "xsec":119.9    , "br":[ 0.5 ],	    "dset":["/QCD_HT1500to2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v3/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_HT1500to2000_ext1_2016", "xsec":119.9    , "br":[ 0.5 ],	    "dset":["/QCD_HT1500to2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+       	{ "dtag":"MC13TeV_QCD_HT2000toInf_2016" , "xsec":25.24     , "br":[ 0.5 ],      "dset":["/QCD_HT2000toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+       	{ "dtag":"MC13TeV_QCD_HT2000toInf_ext1_2016" , "xsec":25.24    , "br":[ 0.5 ],      "dset":["/QCD_HT2000toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]} 
+      ]
+    },
+    {
+      "tag":"QCD_EMEnr",
+      "keys":["2l2v_2016", "2l2v_photoncontrol"],                                                         
+      "isdata":false,
+      "color":24,
+      "data":[
+        { "dtag":"MC13TeV_QCD_Pt20To30_EMEnr_2016"     ,  "xsec":557600000     , "br":[ 0.0096 ]        ,	"dset":["/QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_Pt30To50_EMEnr_2016"     ,  "xsec":136000000     , "br":[ 0.0365 ]         , 	"dset":["/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_Pt30To50_EMEnr_ext1_2016"     ,  "xsec":136000000     , "br":[ 0.0365 ]         , "dset":["/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_Pt50To80_EMEnr_2016"     ,  "xsec":19800000      , "br":[ 0.146 ]         , 	"dset":["/QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_Pt80To120_EMEnr_2016"    ,  "xsec":2800000       , "br":[ 0.125 ]         , 	"dset":["/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_Pt120To170_EMEnr_2016"   ,  "xsec":477000        , "br":[ 0.132 ]         , 	"dset":["/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_Pt170To300_EMEnr_2016"   ,  "xsec":114000        , "br":[ 0.165 ]         , 	"dset":["/QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_Pt300ToInf_EMEnr_2016"   ,  "xsec":9000          , "br":[ 0.15 ]          , 	"dset":["/QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_QCD_Pt20ToInf_MuEnr_2016"   ,  "xsec":720648000       , "br":[ 0.00042 ]       ,	"dset":["/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]} 
+      ]	
+    },	   
+     {
+      "tag":"#gamma+jets",
+      "keys":["2l2v_2016", "2l2v_photoncontrol","2l2v_mcphotonsOnly"],           
+      "isdata":false,
+      "color":390,
+      "2l2v_mcphotonsOnly":{"suffix":"reweighted"},
+      "data":[                                                                     
+        { "dtag":"MC13TeV_GJet_HT-40to100_2016"                  ,  "xsec":20730.0, "br":[ 1.0 ],      "dset":["/GJets_HT-40To100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_GJet_HT-100to200_2016"                 ,  "xsec":9226.0 , "br":[ 1.0 ],      "dset":["/GJets_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v4/MINIAODSIM"]},
+        { "dtag":"MC13TeV_GJet_HT-200to400_2016"                 ,  "xsec":2300.0 , "br":[ 1.0 ],      "dset":["/GJets_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_GJet_HT-400to600_2016"                 ,  "xsec":277.4  , "br":[ 1.0 ],      "dset":["/GJets_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]},
+        { "dtag":"MC13TeV_GJet_HT-600toInf_2016"                 ,  "xsec":93.38  , "br":[ 1.0 ],      "dset":["/GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"]}
+      ]
+    }, 
+    {
+      "tag":"#gamma data",
+      "keys":["2l2v_2016", "2l2v_photoncontrol", "2l2v_photonsOnly"],
+      "isdata":true,
+      "color":1,
+      "fill":0,
+      "marker":20,
+      "msize":0.7,
+      "2l2v_photonsOnly":{"suffix":"reweighted"},
+      "data":[
+          { "dtag":"Data13TeV_SinglePhoton2016B",  "xsec":1.0     , "br":[ 1.0 ]    ,   "dset":["/SinglePhoton/Run2016B-PromptReco-v2/MINIAOD"]      ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt" },
+	  { "dtag":"Data13TeV_SinglePhoton2016C",  "xsec":1.0     , "br":[ 1.0 ]    ,   "dset":["/SinglePhoton/Run2016C-PromptReco-v2/MINIAOD"]      ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt" },
+	   { "dtag":"Data13TeV_SinglePhoton2016D",  "xsec":1.0     , "br":[ 1.0 ]    ,   "dset":["/SinglePhoton/Run2016D-PromptReco-v2/MINIAOD"]      ,  "lumiMask":"$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON.txt" }
+      ]
+    }, 
+    {
+      "tag":"Top/W/WW",
+      "keys":["2l2v_2016", "2l2v_datadrivenplot"],
+      "isdata":false,
+      "isdatadriven":true,
+      "color":8,
+      "syst":[0.21],
+      "nosample":true,
+      "NRB":[{"tag":"data", "scale":1.0}]
+    }, 
+    {
+      "tag":"Genuine (ewk) MET inv",
+      "keys":["2l2v_2016", "genuineMet"],
+      "isinvisible":true,      
+      "isdata":false,
+      "color":41,
+	"mixing":[{"tag":"W#gamma #rightarrow l#nu#gamma_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow ll#gamma_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #nu#nu_reweighted", "scale":1.0}, {"tag":"W#rightarrow l#nu, HT>100_reweighted", "scale":1.0}, {"tag":"Top_reweighted", "scale":1.0},  {"tag":"WZ_reweighted", "scale":1.0},  {"tag":"WW_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #tau#tau_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow #nu#nu#gamma_reweighted", "scale":1.0}, {"tag":"Top+#gamma_reweighted", "scale":1.0} ]
+    },
+    {
+      "tag":"Genuine (ewk) MET",
+      "keys":["2l2v_2016", "genuineMet"],
+      "isdata":false,
+      "color":41,
+      "mixing":[{"tag":"Genuine (ewk) MET inv", "scale":1.0}]
+    },
+    {
+      "tag":"Instr. MET",
+      "keys":["2l2v_2016", "genuineMet", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM",  "2l2v_datadriven_Rad"],
+      "isdata":false,
+      "isdatadriven":true,
+      "color":831,
+      "syst":[0.25],
+      "mixing":[{"tag":"#gamma data_reweighted", "scale":1.0}, {"tag":"Genuine (ewk) MET inv", "scale":-1.0} ]
+    },
+    {
+      "tag":"ggH(200)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_GGtoH200toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/GluGluHToZZTo2L2Nu_M200_13TeV_powheg2_JHUgenV6_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"qqH(200)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_VBFtoH200toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/VBF_HToZZTo2L2Nu_M200_13TeV_powheg2_JHUgenV6_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"ggH(300)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "fill":0,
+      "data":[        { "dtag":"MC13TeV_GGtoH300toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/GluGluHToZZTo2L2Nu_M300_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"qqH(300)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[        
+	{ "dtag":"MC13TeV_VBFtoH300toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/VBF_HToZZTo2L2Nu_M300_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"ggH(400)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "fill":0,
+      "data":[        
+	{ "dtag":"MC13TeV_GGtoH400toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/GluGluHToZZTo2L2Nu_M400_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"qqH(400)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[        
+        { "dtag":"MC13TeV_VBFtoH400toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/VBF_HToZZTo2L2Nu_M400_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"ggH(500)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_GGtoH500toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/GluGluHToZZTo2L2Nu_M500_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"qqH(500)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_VBFtoH500toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/VBF_HToZZTo2L2Nu_M500_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"ggH(600)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":false,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":907,
+      "lwidth":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_GGtoH600toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/GluGluHToZZTo2L2Nu_M600_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"qqH(600)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":false,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":907,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_VBFtoH600toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/VBF_HToZZTo2L2Nu_M600_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"ggH(700)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_GGtoH700toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/GluGluHToZZTo2L2Nu_M700_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"qqH(700)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_VBFtoH700toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/VBF_HToZZTo2L2Nu_M700_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"ggH(800)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_GGtoH800toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/GluGluHToZZTo2L2Nu_M800_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"qqH(800)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_VBFtoH800toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/VBF_HToZZTo2L2Nu_M800_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"ggH(900)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_GGtoH900toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/GluGluHToZZTo2L2Nu_M900_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"qqH(900)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_VBFtoH900toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/VBF_HToZZTo2L2Nu_M900_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"ggH(1000)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":false,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_GGtoH1000toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/GluGluHToZZTo2L2Nu_M1000_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"qqH(1000)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":false,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_VBFtoH1000toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/VBF_HToZZTo2L2Nu_M1000_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"ggH(1500)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_GGtoH1500toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/GluGluHToZZTo2L2Nu_M1500_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"qqH(1500)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_VBFtoH1500toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/VBF_HToZZTo2L2Nu_M1500_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"ggH(2000)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_GGtoH2000toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/GluGluHToZZTo2L2Nu_M2000_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"qqH(2000)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_VBFtoH2000toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/VBF_HToZZTo2L2Nu_M2000_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"ggH(2500)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_GGtoH2500toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/GluGluHToZZTo2L2Nu_M2500_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"qqH(2500)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM", "2l2v_mcbased_SM"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_VBFtoH2500toZZto2L2Nu_powheg_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/VBF_HToZZTo2L2Nu_M2500_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"Rad(600)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_Rad", "2l2v_mcbased_Rad"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_Radion600toZZto2L2Nu_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/RadionToZZToZlepZinv_narrow_M-600_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"Rad(800)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_Rad", "2l2v_mcbased_Rad"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[    
+        { "dtag":"MC13TeV_Radion800toZZto2L2Nu_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/RadionToZZToZlepZinv_narrow_M-800_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"Rad(1000)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_Rad", "2l2v_mcbased_Rad"],
+      "isinvisible":false,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[        
+        { "dtag":"MC13TeV_Radion1000toZZto2L2Nu_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/RadionToZZToZlepZinv_narrow_M-1000_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"Rad(1200)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_Rad", "2l2v_mcbased_Rad"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_Radion1200toZZto2L2Nu_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/RadionToZZToZlepZinv_narrow_M-1200_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"Rad(1600)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_Rad", "2l2v_mcbased_Rad"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_Radion1600toZZto2L2Nu_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/RadionToZZToZlepZinv_narrow_M-1600_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"Rad(1800)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_Rad", "2l2v_mcbased_Rad"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_Radion1800toZZto2L2Nu_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/RadionToZZToZlepZinv_narrow_M-1800_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"Rad(2000)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_Rad", "2l2v_mcbased_Rad"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_Radion2000toZZto2L2Nu_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/RadionToZZToZlepZinv_narrow_M-2000_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"Rad(2500)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_Rad", "2l2v_mcbased_Rad"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_Radion2500toZZto2L2Nu_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/RadionToZZToZlepZinv_narrow_M-2500_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"Rad(3500)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_Rad", "2l2v_mcbased_Rad"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_Radion3500toZZto2L2Nu_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/RadionToZZToZlepZinv_narrow_M-3500_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"Rad(4000)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_Rad", "2l2v_mcbased_Rad"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_Radion4000toZZto2L2Nu_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/RadionToZZToZlepZinv_narrow_M-4000_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    },
+    {
+      "tag":"Rad(4500)",
+      "keys":["2l2v_2016", "2l2v_mcbased", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_Rad", "2l2v_mcbased_Rad"],
+      "isinvisible":true,
+      "isdata":false,
+      "issignal":true,
+      "spimpose":true,
+      "lcolor":619,
+      "lwidth":2,
+      "lstyle":2,
+      "fill":0,
+      "data":[
+        { "dtag":"MC13TeV_Radion4500toZZto2L2Nu_2016"     ,  "xsec":1.0      , "br":[0.029264]    , "dset":["/RadionToZZToZlepZinv_narrow_M-4500_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM"] }
+      ]
+    }
+  ]
+}
+

--- a/test/hzz2l2v/submit.sh
+++ b/test/hzz2l2v/submit.sh
@@ -30,7 +30,7 @@ if [[ $# -ge 4 ]]; then echo "Additional arguments will be considered: "$argumen
 # Global Variables
 #--------------------------------------------------
 
-SUFFIX=_2016_08_05
+SUFFIX=_2016_10_17
 
 #SUFFIX=$(date +"_%Y_%m_%d") 
 MAINDIR=$CMSSW_BASE/src/UserCode/llvv_fwk/test/hzz2l2v
@@ -53,7 +53,7 @@ if [[ $JSON =~ "2016" ]]; then
 else
     pileup=datapileup_official  
 fi
-
+ 
 ################################################# STEPS between 0 and 1
 if [[ $step == 0 ]]; then   
         #analysis cleanup
@@ -81,9 +81,14 @@ if [[ $step > 0.999 &&  $step < 2 ]]; then
    if [[ $step == 1 || $step == 1.2 ]]; then        #submit jobs for 2l2v analysis with photon re-weighting
 	echo "JOB SUBMISSION for Photon + Jet analysis with photon re-weighting"                                                                        
         runAnalysisOverSamples.py -e runHZZ2l2vAnalysis -j $JSON -o $RESULTSDIR -c $MAINDIR/../runAnalysis_cfg.py.templ -p "@data_pileup="$pileup" @useMVA=True @saveSummaryTree=True @weightsFile=$PWD/photonWeights_RunD.root @runSystematics=False @automaticSwitch=False @is2011=False @jacknife=0 @jacks=0" -s $queue --report True --key 2l2v_photonsOnly $arguments 
-   fi                              
+   fi    
+                          
+   if [[ $step == 1 || $step == 1.3 ]]; then        #submit jobs for 2l2v analysis with photon re-weighting in MC                                              
+        echo "JOB SUBMISSION for Photon + Jet analysis with photon re-weighting in MC"                                                                          
+        runAnalysisOverSamples.py -e runHZZ2l2vAnalysis -j $JSON -o $RESULTSDIR -c $MAINDIR/../runAnalysis_cfg.py.templ -p "@data_pileup="$pileup" @useMVA=True  @saveSummaryTree=True @weightsFile=$PWD/photonWeights_run2016MC.root @runSystematics=False @automaticSwitch=False @is2011=False @jacknife=0 @jacks=0" -s $queue --report True --key 2l2v_mcphotonsOnly $arguments                                                                                                             
+   fi    
 
-	 if [[ $HOSTNAME =~ "iihe" ]]; then yes | big-submission $RESULTSDIR/FARM/inputs/big.cmd; fi
+   if [[ $HOSTNAME =~ "iihe" ]]; then yes | big-submission $RESULTSDIR/FARM/inputs/big.cmd; fi
 
  
 fi
@@ -149,7 +154,9 @@ if [[ $step > 2.999 && $step < 4 ]]; then
     fi        
    
     if [[ $step == 3 || $step == 3.01 ]]; then  # make plots and combine root files for photon + jet study    
-        extractPhotonWeights --inFile plotter.root --outFile photonWeights_RunDNew.root --outDir $PLOTSDIR/photonWeights --fitf true
+#        extractPhotonWeights --inFile plotter.root --outFile photonWeights_RunDNew.root --outDir $PLOTSDIR/photonWeights --fitf true
+#	extractPhotonWeights_UsingBins --inFile ${PLOTTER}.root --outFile photonWeights_run2016MC.root --outDir $PLOTSDIR/photonMCWeights --mode MC 
+	extractPhotonWeights_UsingBins --inFile ${PLOTTER}.root --outFile photonWeights_run2016.root --outDir $PLOTSDIR/photonWeights --mode DATA
     fi
 
 

--- a/test/hzz2l2v/submit.sh
+++ b/test/hzz2l2v/submit.sh
@@ -34,7 +34,7 @@ SUFFIX=_2016_10_17
 
 #SUFFIX=$(date +"_%Y_%m_%d") 
 MAINDIR=$CMSSW_BASE/src/UserCode/llvv_fwk/test/hzz2l2v
-JSON=$MAINDIR/samples2016.json 
+JSON=$MAINDIR/samples_ichep2016.json 
 GOLDENJSON=$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/
 RESULTSDIR=$MAINDIR/results$SUFFIX
 PLOTSDIR=$MAINDIR/plots${SUFFIX}

--- a/test/hzz2l2v/submit.sh
+++ b/test/hzz2l2v/submit.sh
@@ -80,7 +80,7 @@ if [[ $step > 0.999 &&  $step < 2 ]]; then
 
    if [[ $step == 1 || $step == 1.2 ]]; then        #submit jobs for 2l2v analysis with photon re-weighting
 	echo "JOB SUBMISSION for Photon + Jet analysis with photon re-weighting"                                                                        
-        runAnalysisOverSamples.py -e runHZZ2l2vAnalysis -j $JSON -o $RESULTSDIR -c $MAINDIR/../runAnalysis_cfg.py.templ -p "@data_pileup="$pileup" @useMVA=True @saveSummaryTree=True @weightsFile=$PWD/photonWeights_RunD.root @runSystematics=False @automaticSwitch=False @is2011=False @jacknife=0 @jacks=0" -s $queue --report True --key 2l2v_photonsOnly $arguments 
+        runAnalysisOverSamples.py -e runHZZ2l2vAnalysis -j $JSON -o $RESULTSDIR -c $MAINDIR/../runAnalysis_cfg.py.templ -p "@data_pileup="$pileup" @useMVA=True @saveSummaryTree=True @weightsFile=$PWD/photonWeights_Run2016.root @runSystematics=False @automaticSwitch=False @is2011=False @jacknife=0 @jacks=0" -s $queue --report True --key 2l2v_photonsOnly $arguments 
    fi    
                           
    if [[ $step == 1 || $step == 1.3 ]]; then        #submit jobs for 2l2v analysis with photon re-weighting in MC                                              


### PR DESCRIPTION
- fixed bug with instr. MET in mumu 0-jet bin 
- added option to run the photon re-weighting with MC weights
- photon weights with 'bin-method' by default for the moment
- removed W->qq process, no need 
- new input samples_ichep2016.json to remove spin-2 models (RsGrav, BulkGrav)