### PR TITLE
Update walltime for IIHE submission

### DIFF
--- a/scripts/LaunchOnCondor.py
+++ b/scripts/LaunchOnCondor.py
@@ -325,7 +325,7 @@ def AddJobToCmdFile():
         cmd_file.write(temp)
     elif subTool=='qsub':
         queue = ""
-        if(commands.getstatusoutput("hostname -f")[1].find("iihe.ac.be"       )>0): queue = ' -q localgrid@cream02 '
+        if(commands.getstatusoutput("hostname -f")[1].find("iihe.ac.be"       )>0): queue = ' -l walltime=20:00:00 '
 
         absoluteShellPath = Path_Shell;
         if(not os.path.isabs(absoluteShellPath)): absoluteShellPath= os.getcwd() + "/" + absoluteShellPath


### PR DESCRIPTION
 - update walltime for IIHE submission from 168h to 20h
 - remove specification of the queue since localgrid is now the default queue