### PR TITLE
[IIHE-only] Better outputs + qpeek explanations

### DIFF
--- a/scripts/LaunchOnCondor.py
+++ b/scripts/LaunchOnCondor.py
@@ -325,7 +325,7 @@ def AddJobToCmdFile():
         cmd_file.write(temp)
     elif subTool=='qsub':
         queue = ""
-        if(commands.getstatusoutput("hostname -f")[1].find("iihe.ac.be"       )>0): queue = ' -l walltime=20:00:00 '
+        if(commands.getstatusoutput("hostname -f")[1].find("iihe.ac.be"       )>0): queue = ' -l walltime=20:00:00 -j oe '
 
         absoluteShellPath = Path_Shell;
         if(not os.path.isabs(absoluteShellPath)): absoluteShellPath= os.getcwd() + "/" + absoluteShellPath


### PR DESCRIPTION
This PR only affects IIHE submission.
It merges the stderr and stdout into a single file.

Furthermore, let me take this opportunity to introduce you a new feature of the cluster: qpeek.
*qpeek* allows you to look at the output of a job when it is still running.

How it works:
 - connect with ssh -A  <+other options>     to *m0*
 - qpeek           => it gives you the different options of the script
 - qpeek -f JOBID   => does a tail -f (and keep listening) on the output file of your job (you can find your job ID with qstat -u $USER); if you want to see the full log (at a given moment of time), just do a "qpeek JOBID".