### PR TITLE
removed cone from getEffectiveArea and trkIso from Muon

### DIFF
--- a/interface/MacroUtils.h
+++ b/interface/MacroUtils.h
@@ -130,7 +130,7 @@ namespace utils
     typedef std::vector<TGraph *> PuShifter_t;
     enum PuShifterTypes {PUDOWN,PUUP};
     utils::cmssw::PuShifter_t getPUshifters(std::vector< float > &Lumi_distr, float puUnc);
-    Float_t getEffectiveArea(int id, float eta,int cone=3,TString isoSum="");
+    Float_t getEffectiveArea(int id, float eta,TString isoSum="");
 //    double relIso(llvvLepton lep, double rho);
 
     // Single muon trigger efficiency 

--- a/src/MacroUtils.cc
+++ b/src/MacroUtils.cc
@@ -296,7 +296,7 @@ namespace utils
     
 
     //
-    Float_t getEffectiveArea(int id,float eta,int cone,TString isoSum)
+    Float_t getEffectiveArea(int id,float eta,TString isoSum)
     {
       Float_t Aeff(1.0);
 

--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -380,13 +380,13 @@ namespace patUtils
     double eta=photon.superCluster()->eta();
 
     float chIso = photon.chargedHadronIso(); 
-    float chArea = utils::cmssw::getEffectiveArea(22,eta,3,"chIso"); 
+    float chArea = utils::cmssw::getEffectiveArea(22,eta,"chIso"); 
 
     float nhIso = photon.neutralHadronIso();
-    float nhArea = utils::cmssw::getEffectiveArea(22,eta,3,"nhIso");
+    float nhArea = utils::cmssw::getEffectiveArea(22,eta,"nhIso");
 
     float gIso = photon.photonIso();
-    float gArea = utils::cmssw::getEffectiveArea(22,eta,3,"gIso");
+    float gArea = utils::cmssw::getEffectiveArea(22,eta,"gIso");
 
     bool barrel = (fabs(eta) <= 1.479);
     bool endcap = (!barrel && fabs(eta) < 2.5);
@@ -491,7 +491,7 @@ namespace patUtils
 	relIso  = (chIso + TMath::Max(0.,nhIso+gIso-0.5*puchIso)) / lep.el.pt();
       }
       else {
-	float effArea = utils::cmssw::getEffectiveArea(11,lep.el.superCluster()->eta(),3);
+	float effArea = utils::cmssw::getEffectiveArea(11,lep.el.superCluster()->eta());
 	relIso  = (chIso + TMath::Max(0.,nhIso+gIso-rho*effArea)) / lep.el.pt();
       }
       
@@ -521,7 +521,7 @@ namespace patUtils
 	    relIso  = (chIso + TMath::Max(0.,nhIso+gIso-0.5*puchIso)) / el.pt();
 	  }
 	  else {
-	    float effArea = utils::cmssw::getEffectiveArea(11,el.superCluster()->eta(),3);
+	    float effArea = utils::cmssw::getEffectiveArea(11,el.superCluster()->eta());
 	    relIso  = (chIso + TMath::Max(0.,nhIso+gIso-rho*effArea)) / el.pt();
 	  }
 	  
@@ -646,11 +646,11 @@ namespace patUtils
        case CutVersion::Moriond17Cut :
            switch(IsoLevel){
               case llvvMuonIso::Loose : 
-                 if( relIso < 0.25 && trkrelIso < 0.1) return true;
+                 if( relIso < 0.25 ) return true;
                  break;
                	 
               case llvvMuonIso::Tight :
-                if( relIso < 0.15 && trkrelIso < 0.05) return true;
+                if( relIso < 0.15 ) return true;
                 break;
              
               default:


### PR DESCRIPTION
Hi,

I have removed cone variable from getEffectiveArea function, which was useless. Also as Hugo suggested (and discussed with Hugues) trkrelIso has been removed.