### PR TITLE
[IIHE-ONLY] Comply with cluster rules

### DIFF
--- a/scripts/runAnalysisOverSamples.py
+++ b/scripts/runAnalysisOverSamples.py
@@ -152,8 +152,9 @@ def getFileList(procData,DefaultNFilesPerJob):
       if(split>0):
          NFilesPerJob = max(1,len(list)/split)
       else:
-         NFilesPerJob = DefaultNFilesPerJob
-         if((len(list)/NFilesPerJob)>100):NFilesPerJob=len(list)/100;  #make sure the number of jobs isn't too big
+         if(hostname.find("iihe.ac.be")!=-1): NFilesPerJob = DefaultNFilesPerJob #at iihe we don't want to have more than the defaultNFilesPerJob
+         elif((len(list)/NFilesPerJob)>100):NFilesPerJob=len(list)/100  #make sure the number of jobs isn't too big
+         else: NFilesPerJob = DefaultNFilesPerJob
 
       for g in range(0, len(list), NFilesPerJob):
          groupList = ''
@@ -204,7 +205,8 @@ parser.add_option('-c', '--cfg'        ,    dest='cfg_file'           , help='ba
 parser.add_option('-r', "--report"     ,    dest='report'             , help='If the report should be sent via email'    , default=False, action="store_true")
 parser.add_option('-D', "--db"         ,    dest='db'                 , help='DB to get file list for a given dset'      , default=DatasetFileDB)
 parser.add_option('-F', "--resubmit"   ,    dest='resubmit'           , help='resubmit jobs that failed'                 , default=False, action="store_true")
-parser.add_option('-S', "--NFile"      ,    dest='NFile'              , help='default #Files per job (for autosplit)'    , default=8)
+if(commands.getstatusoutput("hostname -f")[1].find("iihe.ac.be")!=-1): parser.add_option('-S', "--NFile"      ,    dest='NFile'              , help='default #Files per job (for autosplit)'    , default=6)
+else: parser.add_option('-S', "--NFile"      ,    dest='NFile'              , help='default #Files per job (for autosplit)'    , default=8)
 parser.add_option('-f', "--localnfiles",    dest='localnfiles'        , help='number of parallel jobs to run locally'    , default=8)
 parser.add_option('-l', "--lfn"        ,    dest='crablfn'            , help='user defined directory for CRAB runs'      , default='')
 


### PR DESCRIPTION
This commit affects IIHE only.
It changes the limitation of ROOT files per job:
 - from 8 to 6 as default value
 - remove the limitation of maximum number of jobs per dataset (was set to 100 before, which creates jobs with 20-30 ROOT files (!) hence copying 60GB to the scratch area...)

Please do NOT RUN at IIHE with the old options... you will be killed ;-)