### PR TITLE
Quick fix of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,21 @@ wget https://raw.githubusercontent.com/cms-analysis/HiggsAnalysis-CombinedLimit/
 wget https://raw.githubusercontent.com/cms-analysis/HiggsAnalysis-CombinedLimit/74x-root6/interface/th1fmorph.h -P UserCode/llvv_fwk/interface/
 find UserCode/llvv_fwk/ -type f -name '*.cc' -exec sed -i -e 's/HiggsAnalysis\/CombinedLimit\/interface\/th1fmorph.h/UserCode\/llvv_fwk\/interface\/th1fmorph.h/g' {} \;
 
-scramv1 b -j 16
+scramv1 b -j 16 #WARNING: this won't work! You first need to do "Step to use MELA" below and then compile
 ```
 
 #Step to use MELA
+```bash 
 cd CMSS_X_Y_Z/src
 git clone https://github.com/cms-analysis/HiggsAnalysis-ZZMatrixElement.git ZZMatrixElement
 cd ZZMatrixElement
-. setup.sh -j 12
-
-Now, ONLY after the code has finished to compile insert inside UserCode/llvv_fwk/BuildFile.xml
-<use name="ZZMatrixElement/MELA"/>
-
+sh setup.sh -j 12
 scram b -j 12
+```
+Now, ONLY after the code has finished to compile insert inside UserCode/llvv_fwk/BuildFile.xml
+``` c++
+<use name="ZZMatrixElement/MELA"/>
+```
 
 # An important note about PR in 80X (2016)
 Please before doing your PR, be sure to:


### PR DESCRIPTION
This fixes the layout of the markdown.
Is there a reason why we didn't update once for all the Buildfile.xml with MELA? Since it is needed to compile?