### PR TITLE
update muon ID consistently with Hzz4l

### DIFF
--- a/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
+++ b/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
@@ -1163,13 +1163,13 @@ int main(int argc, char* argv[])
 
              //Cut based identification
              if(is2016MC || is2016data){
-                 passId = lid==11?patUtils::passId(leptons[ilep].el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::ICHEP16Cut) : patUtils::passId(leptons[ilep].mu, vtx[0], patUtils::llvvMuonId::tkHighPT, patUtils::CutVersion::ICHEP16Cut);
+                 passId = lid==11?patUtils::passId(leptons[ilep].el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::ICHEP16Cut) : patUtils::passId(leptons[ilep].mu, vtx[0], patUtils::llvvMuonId::TightAndTlkHighPt, patUtils::CutVersion::ICHEP16Cut);
                  passLooseLepton &= lid==11?patUtils::passId(leptons[ilep].el, vtx[0], patUtils::llvvElecId::Loose, patUtils::CutVersion::ICHEP16Cut) : patUtils::passId(leptons[ilep].mu, vtx[0], patUtils::llvvMuonId::Loose, patUtils::CutVersion::ICHEP16Cut);
                  passSoftMuon &= lid==11? false : patUtils::passId(leptons[ilep].mu, vtx[0], patUtils::llvvMuonId::Soft, patUtils::CutVersion::ICHEP16Cut);
 
                  //isolation
                  //passIso = lid==11?patUtils::passIso(leptons[ilep].el,  patUtils::llvvElecIso::Tight, patUtils::CutVersion::ICHEP16Cut, 0) : patUtils::passIso(leptons[ilep].mu,  patUtils::llvvMuonIso::Tight, patUtils::CutVersion::ICHEP16Cut);
-                 passIso = lid==11?patUtils::passIso(leptons[ilep].el,  patUtils::llvvElecIso::Tight, patUtils::CutVersion::ICHEP16Cut, 0) :   true;
+                 passIso = lid==11?patUtils::passIso(leptons[ilep].el,  patUtils::llvvElecIso::Tight, patUtils::CutVersion::ICHEP16Cut, 0) :   patUtils::passIso(leptons[ilep].mu,  patUtils::llvvMuonIso::H4lWP, patUtils::CutVersion::Moriond17Cut);
                  passLooseLepton &= lid==11?patUtils::passIso(leptons[ilep].el,  patUtils::llvvElecIso::Loose, patUtils::CutVersion::ICHEP16Cut, 0) : patUtils::passIso(leptons[ilep].mu,  patUtils::llvvMuonIso::Loose, patUtils::CutVersion::ICHEP16Cut);
 	     } else {
                  passId = lid==11?patUtils::passId(leptons[ilep].el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::Spring15Cut25ns) : patUtils::passId(leptons[ilep].mu, vtx[0], patUtils::llvvMuonId::Tight, patUtils::CutVersion::Spring15Cut25ns);

--- a/interface/PatUtils.h
+++ b/interface/PatUtils.h
@@ -75,10 +75,10 @@ namespace patUtils
    };
 
    namespace llvvElecId { enum ElecId  {Veto, Loose, Medium, Tight, LooseMVA, MediumMVA, TightMVA}; }
-   namespace llvvMuonId { enum MuonId  {Loose, Soft, Tight, tkHighPT, StdLoose, StdSoft, StdMedium, StdTight}; }
+   namespace llvvMuonId { enum MuonId  {Loose, Soft, Tight, tkHighPT, TightAndTlkHighPt, StdLoose, StdSoft, StdMedium, StdTight}; }
    namespace llvvPhotonId { enum PhotonId  {Loose, Medium, Tight}; }
    namespace llvvElecIso{ enum ElecIso {Veto, Loose, Medium, Tight}; }
-   namespace llvvMuonIso{ enum MuonIso {Loose,Tight}; }
+   namespace llvvMuonIso{ enum MuonIso {Loose,Tight, H4lWP}; }
    namespace CutVersion { enum CutSet {Spring15Cut25ns, ICHEP16Cut, Moriond17Cut}; }
 
    bool passId (VersionedPatElectronSelector id, edm::EventBase const & event, pat::Electron el);

--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -342,7 +342,7 @@ namespace patUtils
 	      {
 	      bool tightID =  mu.isPFMuon() && mu.isGlobalMuon() && mu.globalTrack()->normalizedChi2() < 10. && mu.globalTrack()->hitPattern().numberOfValidMuonHits() > 0. && mu.numberOfMatchedStations() > 1 && fabs(mu.muonBestTrack()->dxy(vtx.position())) < 0.2 && fabs(mu.muonBestTrack()->dz(vtx.position())) < 0.5 && mu.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 && mu.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5; 
               bool tkHighPt = mu.isTrackerMuon() && mu.track().isNonnull() && mu.numberOfMatchedStations() > 1 && (mu.muonBestTrack()->ptError()/mu.muonBestTrack()->pt()) < 0.3 && fabs(mu.muonBestTrack()->dxy(vtx.position()))<0.2 && fabs(mu.muonBestTrack()->dz(vtx.position())) < 0.5 && mu.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 && mu.innerTrack()->hitPattern().trackerLayersWithMeasurement()>5;
-              if (tightID||(mu.pt()&&tkHighPt)) return true;
+              if (tightID||(mu.pt()>200&&tkHighPt)) return true;
               }
             case llvvMuonId::StdLoose :
               if(mu.isLooseMuon()) return true;

--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -338,7 +338,12 @@ namespace patUtils
             case llvvMuonId::tkHighPT :
               if(mu.isTrackerMuon() && mu.track().isNonnull() && mu.numberOfMatchedStations() > 1 && (mu.muonBestTrack()->ptError()/mu.muonBestTrack()->pt()) < 0.3 && fabs(mu.muonBestTrack()->dxy(vtx.position()))<0.2 && fabs(mu.muonBestTrack()->dz(vtx.position())) < 0.5 && mu.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 && mu.innerTrack()->hitPattern().trackerLayersWithMeasurement()>5) return true;
               break;
-              
+            case llvvMuonId::TightAndTlkHighPt :
+	      {
+	      bool tightID =  mu.isPFMuon() && mu.isGlobalMuon() && mu.globalTrack()->normalizedChi2() < 10. && mu.globalTrack()->hitPattern().numberOfValidMuonHits() > 0. && mu.numberOfMatchedStations() > 1 && fabs(mu.muonBestTrack()->dxy(vtx.position())) < 0.2 && fabs(mu.muonBestTrack()->dz(vtx.position())) < 0.5 && mu.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 && mu.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5; 
+              bool tkHighPt = mu.isTrackerMuon() && mu.track().isNonnull() && mu.numberOfMatchedStations() > 1 && (mu.muonBestTrack()->ptError()/mu.muonBestTrack()->pt()) < 0.3 && fabs(mu.muonBestTrack()->dxy(vtx.position()))<0.2 && fabs(mu.muonBestTrack()->dz(vtx.position())) < 0.5 && mu.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 && mu.innerTrack()->hitPattern().trackerLayersWithMeasurement()>5;
+              if (tightID||(mu.pt()&&tkHighPt)) return true;
+              }
             case llvvMuonId::StdLoose :
               if(mu.isLooseMuon()) return true;
               break;
@@ -611,6 +616,11 @@ namespace patUtils
     float  gIso    = mu.pfIsolationR04().sumPhotonEt;
     float  puchIso = mu.pfIsolationR04().sumPUPt;
     float  relIso  = (chIso + TMath::Max(0.,nhIso+gIso-0.5*puchIso)) / mu.pt();
+    float  chIso03   = mu.pfIsolationR04().sumChargedHadronPt;
+    float  nhIso03   = mu.pfIsolationR04().sumNeutralHadronEt;
+    float  gIso03    = mu.pfIsolationR04().sumPhotonEt;
+    float  puchIso03 = mu.pfIsolationR04().sumPUPt;
+    float  relIso03  = (chIso03 + TMath::Max(0.,nhIso03+gIso03-0.5*puchIso03)) / mu.pt();
     float  trkrelIso = mu.isolationR03().sumPt/mu.pt(); // no PU correction
     
     switch(cutVersion){
@@ -656,7 +666,9 @@ namespace patUtils
               case llvvMuonIso::Tight :
                 if( relIso < 0.15 ) return true;
                 break;
-             
+              case llvvMuonIso::H4lWP :
+                if( relIso03 < 0.35 ) return true;
+                break;
               default:
                 printf("FIXME MuonIso llvvMuonIso::%i is unkown\n", IsoLevel);
                 return false;

--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -616,10 +616,10 @@ namespace patUtils
     float  gIso    = mu.pfIsolationR04().sumPhotonEt;
     float  puchIso = mu.pfIsolationR04().sumPUPt;
     float  relIso  = (chIso + TMath::Max(0.,nhIso+gIso-0.5*puchIso)) / mu.pt();
-    float  chIso03   = mu.pfIsolationR04().sumChargedHadronPt;
-    float  nhIso03   = mu.pfIsolationR04().sumNeutralHadronEt;
-    float  gIso03    = mu.pfIsolationR04().sumPhotonEt;
-    float  puchIso03 = mu.pfIsolationR04().sumPUPt;
+    float  chIso03   = mu.pfIsolationR03().sumChargedHadronPt;
+    float  nhIso03   = mu.pfIsolationR03().sumNeutralHadronEt;
+    float  gIso03    = mu.pfIsolationR03().sumPhotonEt;
+    float  puchIso03 = mu.pfIsolationR03().sumPUPt;
     float  relIso03  = (chIso03 + TMath::Max(0.,nhIso03+gIso03-0.5*puchIso03)) / mu.pt();
     float  trkrelIso = mu.isolationR03().sumPt/mu.pt(); // no PU correction
     


### PR DESCRIPTION
update of the muon consistently with [HZZ4l TWiki ](https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsZZ4l2016)

The **loose ID** is replaced by **TightID** for muon with pT < 200 to not increase background too much

_before PR_
<img width="523" alt="zpt_beforepr" src="https://cloud.githubusercontent.com/assets/3070676/22568812/7c9fdaec-e995-11e6-8279-862d1c8ec9b5.png">

_after PR_
<img width="521" alt="zpt_afterpr" src="https://cloud.githubusercontent.com/assets/3070676/22568813/7ca07088-e995-11e6-8e36-c700943d18b7.png">

 