### PR TITLE
new madgraph DY M50toInf sample

### DIFF
--- a/bin/common/runPlotter.cc
+++ b/bin/common/runPlotter.cc
@@ -1074,7 +1074,6 @@ void Draw1DHistogram(JSONWrapper::Object& Root, TFile* File, NameAndType& HistoP
        t2->SetGridy(true);
        t2->SetPad(0,0.0,1.0,0.2);
 
-
        //mc stats+syst
        TH1D *denSystUncH=0;
        if(mcPlusSyst)        denSystUncH=(TH1D *) mcPlusSyst  ->Clone("mcrelunc");
@@ -1108,8 +1107,8 @@ void Draw1DHistogram(JSONWrapper::Object& Root, TFile* File, NameAndType& HistoP
        denSystUncH->GetYaxis()->SetTitle("Data/#Sigma Bkg.");
        denSystUncH->GetXaxis()->SetTitle(""); //drop the tile to gain space
        //denSystUncH->GetYaxis()->CenterTitle(true);
-       denSystUncH->SetMinimum(0.0);
-       denSystUncH->SetMaximum(2.0);
+       denSystUncH->SetMinimum(0.4);
+       denSystUncH->SetMaximum(1.6);
        //denSystUncH->SetMinimum(0);
        //denSystUncH->SetMaximum(data->GetBinContent(data->GetMaximumBin())*1.10);
 
@@ -1196,7 +1195,7 @@ void Draw1DHistogram(JSONWrapper::Object& Root, TFile* File, NameAndType& HistoP
        }
 
       if(data && blind>-1E99){
-	TPave* blinding_box = new TPave(data->GetBinLowEdge(data->FindBin(blind)), 0.0, data->GetXaxis()->GetXmax(), 2.0, 0, "NB" );
+	TPave* blinding_box = new TPave(data->GetBinLowEdge(data->FindBin(blind)), 0.4, data->GetXaxis()->GetXmax(), 1.6, 0, "NB" );
 	blinding_box->SetFillColor(15);         blinding_box->SetFillStyle(3013);         blinding_box->Draw("same F");
 	ObjectToDelete.push_back(blinding_box);
       }

--- a/test/hzz2l2v/samples_full2016.json
+++ b/test/hzz2l2v/samples_full2016.json
@@ -940,14 +940,22 @@
                     "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
                     "xsec": 18610
                 },
+             	{
+		"br": [ 0.35 ],
+		"dset": [
+		" /DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM"
+		],
+		"dtag":  "MC13TeV_DYJetsToLL_50toInf_ext1_2016",
+		"xsec": 5765.4 
+		},
                 {
                     "br": [
-                        1.0
+                        0.65
                     ],
                     "dset": [
-                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_HCALDebug_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+		    "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
                     ],
-                    "dtag": "MC13TeV_DYJetsToLL_50toInf_2016",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext2_2016",
                     "xsec": 5765.4
                 }
             ],
@@ -1161,14 +1169,22 @@
                     "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
                     "xsec": 18610
                 },
+             	{
+		"br": [ 0.35 ],
+		"dset": [
+		" /DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM"
+		],
+		"dtag":  "MC13TeV_DYJetsToLL_50toInf_ext1_2016",
+		"xsec": 5765.4 
+		},
                 {
                     "br": [
-                        1.0
+                        0.65
                     ],
                     "dset": [
-                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_HCALDebug_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+		    "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
                     ],
-                    "dtag": "MC13TeV_DYJetsToLL_50toInf_2016",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext2_2016",
                     "xsec": 5765.4
                 }
             ],

--- a/test/hzz2l2v/samples_full2016_GGH.json
+++ b/test/hzz2l2v/samples_full2016_GGH.json
@@ -756,6 +756,9 @@
             "tag": "Top"
         },
         {
+            "2l2v_photonsOnly": {
+                "suffix": "reweighted"
+            },
             "color": 623,
             "data": [
                 {
@@ -767,24 +770,7 @@
                     ],
                     "dtag": "MC13TeV_WJets_2016",
                     "xsec": 61526.7
-                }
-            ],
-            "isdata": false,
-            "keys": [
-                "2l2v_2016",
-                "2l2v_mcbased",
-                "2l2v_mcbased_SM",
-                "2l2v_datadriven",
-                "2l2v_datadriven_SM"
-            ],
-            "tag": "W#rightarrow l#nu"
-        },
-        {
-            "2l2v_photonsOnly": {
-                "suffix": "reweighted"
-            },
-            "color": 623,
-            "data": [
+                },
                 {
                     "br": [
                         1.0
@@ -905,14 +891,18 @@
                     "dtag": "MC13TeV_WJets_HT-2500ToInf_2016",
                     "xsec": 0.03216
                 }
-            ],
+						],
             "isdata": false,
             "keys": [
                 "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_mcbased_SM",
+                "2l2v_datadriven",
+                "2l2v_datadriven_SM",
                 "2l2v_photoncontrol",
                 "2l2v_photonsOnly"
             ],
-            "tag": "W#rightarrow l#nu, HT>100"
+            "tag": "W#rightarrow l#nu"
         },
         {
             "2l2v_photonsOnly": {
@@ -930,7 +920,7 @@
                     "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
                     "xsec": 18610
                 },
-		{
+     		{
 		"br": [ 0.35 ],
 		"dset": [
 		" /DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM"
@@ -1159,24 +1149,24 @@
                     "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
                     "xsec": 18610
                 },
-		{
-                "br": [ 0.35 ], 
-                "dset": [
-                  "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM"
-                ], 
-                "dtag":  "MC13TeV_DYJetsToLL_50toInf_ext1_2016", 
-                "xsec": 5765.4
-                },     
-                { 
-                "br": [
-		 0.65
-                ],
-                "dset": [
-                  "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"        
-                ],
-                "dtag": "MC13TeV_DYJetsToLL_50toInf_ext2_2016", 
-                 "xsec": 5765.4
-                } 
+             	{
+		"br": [ 0.35 ],
+		"dset": [
+		" /DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM"
+		],
+		"dtag":  "MC13TeV_DYJetsToLL_50toInf_ext1_2016",
+		"xsec": 5765.4 
+		},
+                {
+                    "br": [
+                        0.65
+                    ],
+                    "dset": [
+		    "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext2_2016",
+                    "xsec": 5765.4
+                }
             ],
             "isdata": false,
             "keys": [
@@ -2037,7 +2027,7 @@
            "isinvisible":true,      
            "isdata":false,
            "color":41,
-     	"mixing":[{"tag":"W#gamma #rightarrow l#nu#gamma_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow ll#gamma_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #nu#nu_reweighted", "scale":1.0}, {"tag":"W#rightarrow l#nu, HT>100_reweighted", "scale":1.0}, {"tag":"Top_reweighted", "scale":1.0},  {"tag":"WZ_reweighted", "scale":1.0},  {"tag":"WW_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #tau#tau_filt15_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow #nu#nu#gamma_reweighted", "scale":1.0}, {"tag":"Top+#gamma_reweighted", "scale":1.0}, {"tag":"Z#rightarrow ee-#mu#mu_filt1113_reweighted", "scale":1.0} ]
+     	"mixing":[{"tag":"W#gamma #rightarrow l#nu#gamma_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow ll#gamma_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #nu#nu_reweighted", "scale":1.0}, {"tag":"W#rightarrow l#nu_reweighted", "scale":1.0}, {"tag":"Top_reweighted", "scale":1.0},  {"tag":"WZ_reweighted", "scale":1.0},  {"tag":"WW_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #tau#tau_filt15_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow #nu#nu#gamma_reweighted", "scale":1.0}, {"tag":"Top+#gamma_reweighted", "scale":1.0}, {"tag":"Z#rightarrow ee-#mu#mu_filt1113_reweighted", "scale":1.0} ]
          },
          {
            "tag":"Genuine (ewk) MET",

--- a/test/hzz2l2v/samples_full2016_GGH.json
+++ b/test/hzz2l2v/samples_full2016_GGH.json
@@ -756,9 +756,6 @@
             "tag": "Top"
         },
         {
-            "2l2v_photonsOnly": {
-                "suffix": "reweighted"
-            },
             "color": 623,
             "data": [
                 {
@@ -770,7 +767,24 @@
                     ],
                     "dtag": "MC13TeV_WJets_2016",
                     "xsec": 61526.7
-                },
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_mcbased_SM",
+                "2l2v_datadriven",
+                "2l2v_datadriven_SM"
+            ],
+            "tag": "W#rightarrow l#nu"
+        },
+        {
+            "2l2v_photonsOnly": {
+                "suffix": "reweighted"
+            },
+            "color": 623,
+            "data": [
                 {
                     "br": [
                         1.0
@@ -891,18 +905,14 @@
                     "dtag": "MC13TeV_WJets_HT-2500ToInf_2016",
                     "xsec": 0.03216
                 }
-						],
+            ],
             "isdata": false,
             "keys": [
                 "2l2v_2016",
-                "2l2v_mcbased",
-                "2l2v_mcbased_SM",
-                "2l2v_datadriven",
-                "2l2v_datadriven_SM",
                 "2l2v_photoncontrol",
                 "2l2v_photonsOnly"
             ],
-            "tag": "W#rightarrow l#nu"
+            "tag": "W#rightarrow l#nu, HT>100"
         },
         {
             "2l2v_photonsOnly": {
@@ -920,14 +930,22 @@
                     "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
                     "xsec": 18610
                 },
+		{
+		"br": [ 0.35 ],
+		"dset": [
+		" /DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM"
+		],
+		"dtag":  "MC13TeV_DYJetsToLL_50toInf_ext1_2016",
+		"xsec": 5765.4 
+		},
                 {
                     "br": [
-                        1.0
+                        0.65
                     ],
                     "dset": [
-                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_HCALDebug_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+		    "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
                     ],
-                    "dtag": "MC13TeV_DYJetsToLL_50toInf_2016",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext2_2016",
                     "xsec": 5765.4
                 }
             ],
@@ -1141,16 +1159,24 @@
                     "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
                     "xsec": 18610
                 },
-                {
-                    "br": [
-                        1.0
-                    ],
-                    "dset": [
-                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_HCALDebug_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
-                    ],
-                    "dtag": "MC13TeV_DYJetsToLL_50toInf_2016",
-                    "xsec": 5765.4
-                }
+		{
+                "br": [ 0.35 ], 
+                "dset": [
+                  "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM"
+                ], 
+                "dtag":  "MC13TeV_DYJetsToLL_50toInf_ext1_2016", 
+                "xsec": 5765.4
+                },     
+                { 
+                "br": [
+		 0.65
+                ],
+                "dset": [
+                  "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"        
+                ],
+                "dtag": "MC13TeV_DYJetsToLL_50toInf_ext2_2016", 
+                 "xsec": 5765.4
+                } 
             ],
             "isdata": false,
             "keys": [
@@ -2011,7 +2037,7 @@
            "isinvisible":true,      
            "isdata":false,
            "color":41,
-     	"mixing":[{"tag":"W#gamma #rightarrow l#nu#gamma_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow ll#gamma_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #nu#nu_reweighted", "scale":1.0}, {"tag":"W#rightarrow l#nu_reweighted", "scale":1.0}, {"tag":"Top_reweighted", "scale":1.0},  {"tag":"WZ_reweighted", "scale":1.0},  {"tag":"WW_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #tau#tau_filt15_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow #nu#nu#gamma_reweighted", "scale":1.0}, {"tag":"Top+#gamma_reweighted", "scale":1.0}, {"tag":"Z#rightarrow ee-#mu#mu_filt1113_reweighted", "scale":1.0} ]
+     	"mixing":[{"tag":"W#gamma #rightarrow l#nu#gamma_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow ll#gamma_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #nu#nu_reweighted", "scale":1.0}, {"tag":"W#rightarrow l#nu, HT>100_reweighted", "scale":1.0}, {"tag":"Top_reweighted", "scale":1.0},  {"tag":"WZ_reweighted", "scale":1.0},  {"tag":"WW_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #tau#tau_filt15_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow #nu#nu#gamma_reweighted", "scale":1.0}, {"tag":"Top+#gamma_reweighted", "scale":1.0}, {"tag":"Z#rightarrow ee-#mu#mu_filt1113_reweighted", "scale":1.0} ]
          },
          {
            "tag":"Genuine (ewk) MET",


### PR DESCRIPTION
Replaced DYJetsToLL M50toInf sample (~1M events ) with Madgraph extension samples (total ~150M events ) . 
