### PR TITLE
update for using the isolation safe on boosted Z

### DIFF
--- a/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
+++ b/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
@@ -30,10 +30,10 @@
 #include "PhysicsTools/Utilities/interface/LumiReWeighting.h"
 //#include "TauAnalysis/SVfitStandalone/interface/SVfitStandaloneAlgorithm.h" //for svfit
 
-#include "EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2.h"  
-#include "EgammaAnalysis/ElectronTools/interface/PhotonEnergyCalibratorRun2.h" 
+#include "EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2.h"
+#include "EgammaAnalysis/ElectronTools/interface/PhotonEnergyCalibratorRun2.h"
 
-#include "ZZMatrixElement/MELA/interface/Mela.h" 
+#include "ZZMatrixElement/MELA/interface/Mela.h"
 
 #include "UserCode/llvv_fwk/interface/MacroUtils.h"
 #include "UserCode/llvv_fwk/interface/HiggsUtils.h"
@@ -82,13 +82,13 @@ int main(int argc, char* argv[])
 
   // check arguments
   if(argc<2){ std::cout << "Usage : " << argv[0] << " parameters_cfg.py" << std::endl; exit(0); }
-  
+
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
 //  AutoLibraryLoader::enable();
   FWLiteEnabler::enable();
 
-  
+
   // configure the process
   const edm::ParameterSet &runProcess = edm::readPSetsFrom(argv[1])->getParameter<edm::ParameterSet>("runProcess");
 
@@ -112,9 +112,9 @@ int main(int argc, char* argv[])
       if(dtag.Contains("DoubleEle"))   filterOnlyEE=true;
       if(dtag.Contains("DoubleMu"))    filterOnlyMUMU=true;
       if(dtag.Contains("MuEG"))        filterOnlyEMU=true;
-      if(dtag.Contains("SinglePhoton"))filterOnlyPhoton=true;     
-      if(dtag.Contains("SingleMu"))    filterOnlyMU=true;      
-      if(dtag.Contains("SingleElectron"))filterOnlyE=true;      
+      if(dtag.Contains("SinglePhoton"))filterOnlyPhoton=true;
+      if(dtag.Contains("SingleMu"))    filterOnlyMU=true;
+      if(dtag.Contains("SingleElectron"))filterOnlyE=true;
   }
   bool isV0JetsMC(false);//isMC && (dtag.Contains("DYJetsToLL_50toInf") || dtag.Contains("_WJets")));  #FIXME should be reactivated as soon as we have exclusive jet samples
   bool isOldMC(isMC && dtag.Contains("old"));
@@ -127,17 +127,17 @@ int main(int argc, char* argv[])
   bool isMC_ZZ  = isMC && ( string(dtag.Data()).find("TeV_ZZ")  != string::npos);
   bool isMC_ZZ2l2nu  = isMC && ( string(dtag.Data()).find("TeV_ZZ2l2nu")  != string::npos);
   bool isMC_ggZZ2mu2nu = isMC && (string(dtag.Data()).find("TeV_ggZZ2mu2nu") != string::npos);
-  bool isMC_ggZZ2e2nu = isMC && (string(dtag.Data()).find("TeV_ggZZ2e2nu") != string::npos); 
+  bool isMC_ggZZ2e2nu = isMC && (string(dtag.Data()).find("TeV_ggZZ2e2nu") != string::npos);
   bool isMC_WZ  = isMC && ( string(dtag.Data()).find("TeV_WZ")  != string::npos);
   bool isMC_WZ3lnu  = isMC && ( string(dtag.Data()).find("TeV_WZ3lnu")  != string::npos);
   bool isMC_Wlnu_inclusive = (isMC && dtag.Contains("_WJets_") && !dtag.Contains("HT"));
   bool isMC_Wlnu_HT100 = (isMC && dtag.Contains("_WJets_HT-") );
   bool isMC_QCD = (isMC && dtag.Contains("QCD"));
   bool isMC_GJet = (isMC && dtag.Contains("GJet"));
-  bool is2015data = (!isMC && dtag.Contains("2015")); 
-  bool is2015MC = (isMC && dtag.Contains("2015")); 
-  bool is2016data = (!isMC && dtag.Contains("2016")); 
-  bool is2016MC = (isMC && dtag.Contains("2016")); 
+  bool is2015data = (!isMC && dtag.Contains("2015"));
+  bool is2015MC = (isMC && dtag.Contains("2015"));
+  bool is2016data = (!isMC && dtag.Contains("2016"));
+  bool is2016MC = (isMC && dtag.Contains("2016"));
   bool isMC_signal  = isMC && ( (string(dtag.Data()).find("GG" )  != string::npos) ||(string(dtag.Data()).find("VBF")  != string::npos )||dtag.Contains("RsGrav")||dtag.Contains("BulkGrav") || dtag.Contains("Radion") );
   bool isMELA = isMC_signal && ( dtag.Contains("MELA") );
   bool isReHLT = isMC && ( ReHLT_inMC.Contains("reHLT") );
@@ -175,7 +175,7 @@ int main(int argc, char* argv[])
         varNames.push_back("_scale_jup");    varNames.push_back("_scale_jdown");  //jet energy scale
         varNames.push_back("_scale_mup");    varNames.push_back("_scale_mdown");  //muon energy scale
         varNames.push_back("_scale_eup");    varNames.push_back("_scale_edown");  //electron energy scale
-        varNames.push_back("_puup");         varNames.push_back("_pudown");      //pileup uncertainty 
+        varNames.push_back("_puup");         varNames.push_back("_pudown");      //pileup uncertainty
         varNames.push_back("_eff_bup");      varNames.push_back("_eff_bdown");    //btag veto
         varNames.push_back("_lepveto");                                           //3rd lepton veto
         varNames.push_back("_th_factup");    varNames.push_back("_th_factdown"); //factorization and renormalization scales
@@ -191,27 +191,27 @@ int main(int argc, char* argv[])
      }
   }
   size_t nvarsToInclude=varNames.size();
-  
+
   std::vector<std::string> allWeightsURL=runProcess.getParameter<std::vector<std::string> >("weightsFile");
   std::string weightsDir( allWeightsURL.size() ? allWeightsURL[0] : "");
 
-  std::vector<std::string> gammaPtWeightsFiles =  runProcess.getParameter<std::vector<std::string> >("weightsFile");      
+  std::vector<std::string> gammaPtWeightsFiles =  runProcess.getParameter<std::vector<std::string> >("weightsFile");
   GammaWeightsHandler* gammaWgtHandler = (gammaPtWeightsFiles.size()>0 && gammaPtWeightsFiles[0]!="") ? new GammaWeightsHandler(runProcess,"",true) : NULL;
 
   // Apply pu corrections to photon sample, to match the pu distribution in the dilepton one
-  std::vector<std::string> puWeightsFilePath = runProcess.getParameter<std::vector<std::string> >("puWeightsFile"); 
+  std::vector<std::string> puWeightsFilePath = runProcess.getParameter<std::vector<std::string> >("puWeightsFile");
 
-  bool doPUCorrections=true;    
-  if ( puWeightsFilePath.size()==0) {doPUCorrections=false; }     
+  bool doPUCorrections=true;
+  if ( puWeightsFilePath.size()==0) {doPUCorrections=false; }
   else if ( puWeightsFilePath[0]=="") {doPUCorrections=false; }
 
-  TFile* puWeightsFile=NULL;  
+  TFile* puWeightsFile=NULL;
 
   if(gammaWgtHandler)printf("gammaWgtHandler is activated\n");
 
   //HIGGS weights and uncertainties
-  
-  //narrow resonance    
+
+  //narrow resonance
   std::vector<std::pair<double, double> > NRparams;
   if(mctruthmode==125){
 //    NRparams.push_back(std::make_pair<double,double>(5, -1));  //vary the width
@@ -230,8 +230,8 @@ int main(int argc, char* argv[])
 //    NRparams.push_back(std::make_pair<double,double>(22,-1));
 //    NRparams.push_back(std::make_pair<double,double>(25,-1));
 //    NRparams.push_back(std::make_pair<double,double>(30,-1));
-  }else if( (suffix=="" || isMELA)  && (isMC_GG || isMC_VBF)){ //consider the other points only when no suffix is being used    
-  
+  }else if( (suffix=="" || isMELA)  && (isMC_GG || isMC_VBF)){ //consider the other points only when no suffix is being used
+
       //NRparams.push_back(std::make_pair<double,double>( 100.0, 0.0) );
       //NRparams.push_back(std::make_pair<double,double>(  10.0, 0.0) );
       //NRparams.push_back(std::make_pair<double,double>(   0.0, 0.0) );
@@ -243,7 +243,7 @@ int main(int argc, char* argv[])
   }
   if(NRparams.size()<=0)NRparams.push_back(std::make_pair<double,double>(-1.0, -1.0)); //no reweighting
 
-  std::vector<TString>    NRsuffix; 
+  std::vector<TString>    NRsuffix;
   std::vector<double[6] > lShapeWeights(NRparams.size());   //WEIGHT for LineShape (NNLO kFactors + Interf), split in shape and scale unc with the following format:  scaleNominal, shapeNominal, scaleDown, shapeDown, scaleUp, shapeUp
   std::vector< std::map<TString,double> > lMelaShapeWeights(NRparams.size());
   std::map< TString, double> MelaWeigthsMap;
@@ -252,26 +252,26 @@ int main(int argc, char* argv[])
      char tmp[255];
      if(      NRparams[nri].first<0 && NRparams[nri].second<0){   sprintf(tmp,"%s", "");
      }else if(NRparams[nri].first>0 && NRparams[nri].second<0){   sprintf(tmp,"_width%6.2f"      , NRparams[nri].first);
-     }else{                                                       sprintf(tmp,"_cp%3.2f_brn%3.2f",NRparams[nri].first, NRparams[nri].second); 
-     } 
+     }else{                                                       sprintf(tmp,"_cp%3.2f_brn%3.2f",NRparams[nri].first, NRparams[nri].second);
+     }
      NRsuffix.push_back(TString(tmp));
   }
 
-  
+
   //STANDARD MODEL
   double HiggsMass=0; string VBFString = ""; string GGString("");
   TF1 *decayProbPdf=new TF1("relbw","(2*sqrt(2)*[0]*[1]*sqrt(pow([0],2)*(pow([0],2)+pow([1],2)))/(TMath::Pi()*sqrt(pow([0],2)+sqrt(pow([0],2)*(pow([0],2)+pow([1],2))))))/(pow(pow(x,2)-pow([0],2),2)+pow([0]*[1],2))",0,2000);
-  if(isMC_GG){  
+  if(isMC_GG){
     size_t GGStringpos =  string(dtag.Data()).find("GG");
     string StringMass = string(dtag.Data()).substr(GGStringpos+5,4);  sscanf(StringMass.c_str(),"%lf",&HiggsMass);
-    GGString = string(dtag.Data()).substr(GGStringpos);  
+    GGString = string(dtag.Data()).substr(GGStringpos);
   }else if(isMC_VBF){
     size_t VBFStringpos =  string(dtag.Data()).find("VBF");
     string StringMass = string(dtag.Data()).substr(VBFStringpos+6,4);  sscanf(StringMass.c_str(),"%lf",&HiggsMass);
     VBFString = string(dtag.Data()).substr(VBFStringpos);
   }
   if(mctruthmode==125) HiggsMass=124;
-  
+
 
   //ELECTROWEAK CORRECTION WEIGHTS
   std::vector<std::vector<float>> ewkTable, ZZ_NNLOTable;
@@ -285,13 +285,13 @@ int main(int argc, char* argv[])
 
   //NNLO Correction for ggHZZ and ggZZ processes. They are computed as a function of the invariant mass of the final state using HNNLO.
   double nnlo_ggH_kFact=1.0;
-  TGraph* HNNLO_Wgt_Gr = higgs::utils::Get_NNLO_kFactors(); 
+  TGraph* HNNLO_Wgt_Gr = higgs::utils::Get_NNLO_kFactors();
 
 
   //#######################################
   //####      LINE SHAPE WEIGHTS       ####
   //#######################################
-  std::map<std::pair<double,double>, std::vector<std::pair<double, TGraph *> > > hLineShapeGrVec;  
+  std::map<std::pair<double,double>, std::vector<std::pair<double, TGraph *> > > hLineShapeGrVec;
   if(isMC_GG || isMC_VBF){
       TH1D* hGen=new TH1D("hGen", "hGen", 2000, 0, 8000);
       utils::getHiggsLineshapeFromMiniAOD(urls, hGen);
@@ -306,12 +306,12 @@ int main(int argc, char* argv[])
       } else if( isMC_GG ){
 	//TString nrLineShapesFileUrl(string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/weights/NR_weightsRun2.root");
 	TString nrLineShapesFileUrl(string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/weights/Weights_EWS_GGH_21June2016_AllInterferences.root");
-	//Weights_EWS_GGH_21June2016_AllInterferences.root"); 
+	//Weights_EWS_GGH_21June2016_AllInterferences.root");
 	gSystem->ExpandPathName(nrLineShapesFileUrl);
 	nrLineShapesFile=TFile::Open(nrLineShapesFileUrl);
       } else if( isMC_VBF ){
         TString nrLineShapesFileUrl(string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/weights/Weights_EWS_VBF_21June2016_AllInterferences.root");
-	//Weights_EWS_VBF_21June2016_AllInterferences.root"); 
+	//Weights_EWS_VBF_21June2016_AllInterferences.root");
         gSystem->ExpandPathName(nrLineShapesFileUrl);
         nrLineShapesFile=TFile::Open(nrLineShapesFileUrl);
       }
@@ -328,12 +328,12 @@ int main(int argc, char* argv[])
          TGraph* nrWgtGr=NULL; TGraph* nrWgtUpGr=NULL; TGraph* nrWgtDownGr=NULL;
          if(isGGZZContinuum){
             nrWgtGr     = higgs::utils::weightGGZZContinuum(nrLineShapesFile,signalNorm    ,""  );
-            nrWgtUpGr   = higgs::utils::weightGGZZContinuum(nrLineShapesFile,signalUpNorm  ,"Up");         
-            nrWgtDownGr = higgs::utils::weightGGZZContinuum(nrLineShapesFile,signalDownNorm,"Dn");        
+            nrWgtUpGr   = higgs::utils::weightGGZZContinuum(nrLineShapesFile,signalUpNorm  ,"Up");
+            nrWgtDownGr = higgs::utils::weightGGZZContinuum(nrLineShapesFile,signalDownNorm,"Dn");
          }else if(mctruthmode!=125 && NRparams[nri].first>=0){
             nrWgtGr     = higgs::utils::weightNarrowResonnance(isMC_VBF,HiggsMass, NRparams[nri].first, NRparams[nri].second, nrLineShapesFile,signalNorm    ,""     );
-            nrWgtUpGr   = higgs::utils::weightNarrowResonnance(isMC_VBF,HiggsMass, NRparams[nri].first, NRparams[nri].second, nrLineShapesFile,signalUpNorm  ,"_up"  );          
-            nrWgtDownGr = higgs::utils::weightNarrowResonnance(isMC_VBF,HiggsMass, NRparams[nri].first, NRparams[nri].second, nrLineShapesFile,signalDownNorm,"_down"); 
+            nrWgtUpGr   = higgs::utils::weightNarrowResonnance(isMC_VBF,HiggsMass, NRparams[nri].first, NRparams[nri].second, nrLineShapesFile,signalUpNorm  ,"_up"  );
+            nrWgtDownGr = higgs::utils::weightNarrowResonnance(isMC_VBF,HiggsMass, NRparams[nri].first, NRparams[nri].second, nrLineShapesFile,signalDownNorm,"_down");
          }
          if(!nrWgtUpGr){nrWgtUpGr=nrWgtGr;  signalUpNorm=signalNorm;}
          if(!nrWgtDownGr){nrWgtDownGr=nrWgtGr;  signalDownNorm=signalNorm;}
@@ -343,9 +343,9 @@ int main(int argc, char* argv[])
     	     Double_t hmass    = hGen->GetBinCenter(ip);
 	     Double_t hy       = hGen->GetBinContent(ip);
              hySum            += hy;
-		  
+
 	     Double_t shapeWgt(1.0),shapeWgtUp(1.0),shapeWgtDown(1.0);
-             if(mctruthmode==125){  //reweighting to SM higgs width various width 
+             if(mctruthmode==125){  //reweighting to SM higgs width various width
                 TString var("");
    	        if(dtag.Contains("ScaleUp"))   var="up";
 	        if(dtag.Contains("ScaleDown")) var="down";
@@ -355,19 +355,19 @@ int main(int argc, char* argv[])
  	     }else if(NRparams[nri].first>=0 || isGGZZContinuum){ //reweighting to Narrow reasonnance or EWS model, or to ggZZ continuum
                 shapeWgt       = nrWgtGr    ->Eval(hmass);
                 shapeWgtUp     = nrWgtUpGr  ->Eval(hmass);
-                shapeWgtDown   = nrWgtDownGr->Eval(hmass);                       
+                shapeWgtDown   = nrWgtDownGr->Eval(hmass);
              }else{ //unknown case, do not reweight  (SM-Like)
      	        shapeWgt     = 1.0;
 	        shapeWgtUp   = 1.0;
  	        shapeWgtDown = 1.0;
   	     }
-	
+
              //if(ip==150)printf("weight for mZZ %f = %f x %f\n", hmass, shapeWgt, hy);
 	     shapeWgtsGr     ->SetPoint(shapeWgtsGr     ->GetN(), hmass, shapeWgt);       shapeNorm     += shapeWgt*hy;
 	     shapeWgts_upGr  ->SetPoint(shapeWgts_upGr  ->GetN(), hmass, shapeWgtUp);     shapeUpNorm   += shapeWgtUp*hy;
 	     shapeWgts_downGr->SetPoint(shapeWgts_downGr->GetN(), hmass, shapeWgtDown);   shapeDownNorm += shapeWgtDown*hy;
          }
-	      
+
          if(mctruthmode!=125){
 	    if(hySum>0){
 	       shapeNorm     /= hySum;
@@ -380,9 +380,9 @@ int main(int argc, char* argv[])
  	    for(Int_t ip=0; ip<shapeWgtsGr->GetN(); ip++){
   	         Double_t x,y;
 	         shapeWgtsGr->GetPoint(ip,x,y);
-	         shapeWgtsGr->SetPoint(ip,x,y/shapeNorm);   
+	         shapeWgtsGr->SetPoint(ip,x,y/shapeNorm);
  	         shapeWgts_upGr->GetPoint(ip,x,y);
-	         shapeWgts_upGr->SetPoint(ip,x,y/shapeUpNorm);		    
+	         shapeWgts_upGr->SetPoint(ip,x,y/shapeUpNorm);
   	         shapeWgts_downGr->GetPoint(ip,x,y);
 	         shapeWgts_downGr->SetPoint(ip,x,y/shapeDownNorm);
 	    }
@@ -391,7 +391,7 @@ int main(int argc, char* argv[])
          //all done here...
 	 std::vector<std::pair<double, TGraph*> > inrWgts = {std::make_pair(signalNorm/signalNorm, shapeWgtsGr), std::make_pair(signalUpNorm/signalNorm,shapeWgts_upGr), std::make_pair(signalDownNorm/signalNorm,shapeWgts_downGr)};
 	 hLineShapeGrVec[ NRparams[nri] ] = inrWgts;
-      }	  
+      }
       if(nrLineShapesFile){nrLineShapesFile->Close(); delete nrLineShapesFile;}
   }
 
@@ -406,7 +406,7 @@ int main(int argc, char* argv[])
   ((TH1F*)mon.addHistogram( new TH1F( "higgsMass_raw",      ";Higgs Mass [GeV];Events", 2000, 0, 5000) ))->Fill(-1.0,0.0001);
   ((TH1F*)mon.addHistogram( new TH1F( "higgsMass_nnlo_raw", ";Higgs Mass [GeV];Events", 2000, 0, 5000) ))->Fill(-1.0,0.0001);
   for(unsigned int nri=0;nri<NRparams.size();nri++){
-    ((TH1F*)mon.addHistogram( new TH1F( "MELA_weights"+NRsuffix[nri] , ";Wgt; Events", 10000, 0, 100)))->Fill(-1.0,0.0001); 
+    ((TH1F*)mon.addHistogram( new TH1F( "MELA_weights"+NRsuffix[nri] , ";Wgt; Events", 10000, 0, 100)))->Fill(-1.0,0.0001);
     ((TH1F*)mon.addHistogram( new TH1F( "higgsMass_shape"+NRsuffix[nri] , ";Higgs Mass;Events [GeV]", 2000, 0, 5000) ))->Fill(-1.0,0.0001);
     ((TH1F*)mon.addHistogram( new TH1F( "higgsMass_shape&scale"+NRsuffix[nri] , ";Higgs Mass;Events [GeV]", 2000, 0, 5000) ))->Fill(-1.0,0.0001);
   }
@@ -415,18 +415,18 @@ int main(int argc, char* argv[])
   mon.addHistogram( new TH1F( "zdecays",     ";Z decay channel",6,0,6) );
 
   //  mon.addHistogram( new TH1F( "metFilter_eventflow",     ";metEventflow",20,0,20) );
-  TH1F *hm=(TH1F*) mon.addHistogram( new TH1F( "metFilter_eventflow",     ";metEventflow",20,0,20) ); 
-  hm->GetXaxis()->SetBinLabel(1,"raw"); 
-  hm->GetXaxis()->SetBinLabel(2,"globalTightHalo2016Filter"); 
-  hm->GetXaxis()->SetBinLabel(3,"goodVertices"); 
-  hm->GetXaxis()->SetBinLabel(4,"eeBadScFilter"); 
-  hm->GetXaxis()->SetBinLabel(5,"EcalDeadCellTriggerPrimitiveFilter"); 
-  hm->GetXaxis()->SetBinLabel(6,"HBHENoiseFilter"); 
-  hm->GetXaxis()->SetBinLabel(7,"HBHENoiseIsoFilter"); 
-  hm->GetXaxis()->SetBinLabel(8,"BadPFMuonFilter"); 
-  hm->GetXaxis()->SetBinLabel(9,"BadChargedCandidateFilte"); 
-  hm->GetXaxis()->SetBinLabel(10,"badMuonHIPFilter"); 
-  hm->GetXaxis()->SetBinLabel(11,"duplicateMuonHIPFilter"); 
+  TH1F *hm=(TH1F*) mon.addHistogram( new TH1F( "metFilter_eventflow",     ";metEventflow",20,0,20) );
+  hm->GetXaxis()->SetBinLabel(1,"raw");
+  hm->GetXaxis()->SetBinLabel(2,"globalTightHalo2016Filter");
+  hm->GetXaxis()->SetBinLabel(3,"goodVertices");
+  hm->GetXaxis()->SetBinLabel(4,"eeBadScFilter");
+  hm->GetXaxis()->SetBinLabel(5,"EcalDeadCellTriggerPrimitiveFilter");
+  hm->GetXaxis()->SetBinLabel(6,"HBHENoiseFilter");
+  hm->GetXaxis()->SetBinLabel(7,"HBHENoiseIsoFilter");
+  hm->GetXaxis()->SetBinLabel(8,"BadPFMuonFilter");
+  hm->GetXaxis()->SetBinLabel(9,"BadChargedCandidateFilte");
+  hm->GetXaxis()->SetBinLabel(10,"badMuonHIPFilter");
+  hm->GetXaxis()->SetBinLabel(11,"duplicateMuonHIPFilter");
 
   //event selection
   TH1F *h=(TH1F*) mon.addHistogram( new TH1F ("eventflow", ";;Events", 10,0,10) );
@@ -435,7 +435,7 @@ int main(int argc, char* argv[])
   h->GetXaxis()->SetBinLabel(3,"|M-91|<15");
   h->GetXaxis()->SetBinLabel(4,"p_{T}>55");
   h->GetXaxis()->SetBinLabel(5,"3^{rd}-lepton veto");
-  h->GetXaxis()->SetBinLabel(6,"b-veto"); 
+  h->GetXaxis()->SetBinLabel(6,"b-veto");
   h->GetXaxis()->SetBinLabel(7,"#Delta #phi(jet,E_{T}^{miss})>0.5");
   h->GetXaxis()->SetBinLabel(8,"E_{T}^{miss}>80");
   h->GetXaxis()->SetBinLabel(9,"E_{T}^{miss}>125");
@@ -447,31 +447,31 @@ int main(int argc, char* argv[])
   h->GetXaxis()->SetBinLabel(3,"ee");
   h->GetXaxis()->SetBinLabel(4,"e");
   h->GetXaxis()->SetBinLabel(5,"e#mu");
-  h->GetXaxis()->SetBinLabel(6,"#gamma"); 
+  h->GetXaxis()->SetBinLabel(6,"#gamma");
 
   //pu control
-  mon.addHistogram( new TH1F( "nvtx",";Vertices;Events",81, -0.5, 80.5)); //50,0,50) ); 
-  mon.addHistogram( new TH1F( "nvtxraw",";Vertices;Events",81, -0.5, 80.5 )); //50,0,50) ); 
-  mon.addHistogram( new TH1F( "rho",";#rho;Events",100,0,50) ); 
+  mon.addHistogram( new TH1F( "nvtx",";Vertices;Events",81, -0.5, 80.5)); //50,0,50) );
+  mon.addHistogram( new TH1F( "nvtxraw",";Vertices;Events",81, -0.5, 80.5 )); //50,0,50) );
+  mon.addHistogram( new TH1F( "rho",";#rho;Events",100,0,50) );
 
-  Double_t ZPtBins[] = {0,30,36,50,75,90,120,165,3000}; 
-  Int_t NZPtBins = sizeof(ZPtBins)/sizeof(ZPtBins[0]) - 1; 
+  Double_t ZPtBins[] = {0,30,36,50,75,90,120,165,3000};
+  Int_t NZPtBins = sizeof(ZPtBins)/sizeof(ZPtBins[0]) - 1;
   Double_t RhoBins[] = {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100};
 
-  Int_t NRhoBins = sizeof(RhoBins)/sizeof(RhoBins[0]) - 1; 
+  Int_t NRhoBins = sizeof(RhoBins)/sizeof(RhoBins[0]) - 1;
 
-  TH2F *hnvtx=(TH2F *) mon.addHistogram( new TH2F ("zpt_vs_nvtx",";zpt;#vertices",NZPtBins, ZPtBins, NRhoBins, RhoBins) ); 
-  TH2F *hrho=(TH2F *) mon.addHistogram( new TH2F ("zpt_vs_rho",";zpt;rho", NZPtBins, ZPtBins, NRhoBins, RhoBins) ); 
+  TH2F *hnvtx=(TH2F *) mon.addHistogram( new TH2F ("zpt_vs_nvtx",";zpt;#vertices",NZPtBins, ZPtBins, NRhoBins, RhoBins) );
+  TH2F *hrho=(TH2F *) mon.addHistogram( new TH2F ("zpt_vs_rho",";zpt;rho", NZPtBins, ZPtBins, NRhoBins, RhoBins) );
 
   // photon control
-  mon.addHistogram(new TH1F("npho",   ";Number of Photons;Events", 20, 0, 20) ); 
-  mon.addHistogram(new TH1F("npho55", ";Number of Photons;Events", 20, 0, 20) ); 
-  mon.addHistogram(new TH1F("npho100",";Number of Photons;Events", 20, 0, 20) ); 
-  mon.addHistogram(new TH1F("photonpt", ";Photon pT [GeV];Events", 500, 0, 1000) ); 
-  mon.addHistogram(new TH1F("phopt", ";Photon pT [GeV];Events", 500, 0, 1000) ); 
+  mon.addHistogram(new TH1F("npho",   ";Number of Photons;Events", 20, 0, 20) );
+  mon.addHistogram(new TH1F("npho55", ";Number of Photons;Events", 20, 0, 20) );
+  mon.addHistogram(new TH1F("npho100",";Number of Photons;Events", 20, 0, 20) );
+  mon.addHistogram(new TH1F("photonpt", ";Photon pT [GeV];Events", 500, 0, 1000) );
+  mon.addHistogram(new TH1F("phopt", ";Photon pT [GeV];Events", 500, 0, 1000) );
   mon.addHistogram(new TH1F("phoeta", ";Photon pseudo-rapidity;Events", 50, 0, 5) );
   mon.addHistogram(new TH1F("bosonnvtx", ";Photon #vertices;Events", 81, -0.5, 80.5) );
-  mon.addHistogram(new TH1F("bosonrho", ";Photon rho;Events",100,0,50) ); 
+  mon.addHistogram(new TH1F("bosonrho", ";Photon rho;Events",100,0,50) );
 
   mon.addHistogram(new TH1F("bosoneta", ";Photon #eta;Events", 100, -5, 5) );
   mon.addHistogram(new TH1F("bosonphi", ";Photon #phi;Events", 80, -4, 4) );
@@ -479,7 +479,7 @@ int main(int argc, char* argv[])
   mon.addHistogram(new TH1F("metphi", ";MET #phi;Events", 80, -4, 4) );
   mon.addHistogram(new TH1F("metphiUnCor", ";MET #phi;Events", 80, -4, 4) );
   mon.addHistogram(new TH1F("dphi_boson_met", ";#Delta #phi(#gamma,MET);Events", 40, 0, 4) );
-  
+
   //lepton control
   mon.addHistogram( new TH1F( "nleptons",   ";Nleptons;Events",10,0,10) );
   mon.addHistogram( new TH1F( "leadpt",     ";Transverse momentum [GeV];Events", 50,0,500) );
@@ -516,9 +516,9 @@ int main(int argc, char* argv[])
   mon.addHistogram( new TH1F("csvothers",";Combined Secondary Vertex;Jets",50,0.,1.) );
   mon.addHistogram( new TH1F("leadjetpt",    ";Transverse momentum [GeV];Events",50,0,1000) );
 
-  mon.addHistogram( new TH1F("leadjet_pt",    ";Transverse momentum [GeV];Events",50,0,1000) );  
-  mon.addHistogram( new TH1F("leadjet_eta",    ";Pseudo-rapidity;Events",25,0,5) );   
-  mon.addHistogram( new TH1F("leadjet_phi",    ";leadjet #phi;Events",80, -4, 4) );        
+  mon.addHistogram( new TH1F("leadjet_pt",    ";Transverse momentum [GeV];Events",50,0,1000) );
+  mon.addHistogram( new TH1F("leadjet_eta",    ";Pseudo-rapidity;Events",25,0,5) );
+  mon.addHistogram( new TH1F("leadjet_phi",    ";leadjet #phi;Events",80, -4, 4) );
 
   mon.addHistogram( new TH1F("trailerjetpt", ";Transverse momentum [GeV];Events",50,0,1000) );
   mon.addHistogram( new TH1F("vbfjeteta",    ";Pseudo-rapidity;Events",25,0,5) );
@@ -529,7 +529,7 @@ int main(int argc, char* argv[])
   mjjaxis[0]=0.01;
   for(size_t i=1; i<20; i++)  mjjaxis[i]   =50*i;        //0-1000
   for(size_t i=0; i<5; i++)   mjjaxis[20+i]=1000+100*i; //1000-1500
-  for(size_t i=0; i<=10; i++)   mjjaxis[25+i]=1500+300*i; //1500-5000  
+  for(size_t i=0; i<=10; i++)   mjjaxis[25+i]=1500+300*i; //1500-5000
   mjjaxis[36]=9000;
   mon.addHistogram( new TH1F("vbfmjj"       , ";Dijet invariant mass [GeV];Events / GeV",31,mjjaxis) );
   mon.addHistogram( new TH1F("vbfdphijj"    , ";Azimuthal angle difference;Events",20,0,3.5) );
@@ -543,9 +543,9 @@ int main(int argc, char* argv[])
       if(ibin==h->GetXaxis()->GetNbins()) label +="#geq";
       label += (ibin-1);
       hjets   ->GetXaxis()->SetBinLabel(ibin,label);
-      hjetsfinal->GetXaxis()->SetBinLabel(ibin,label);      
+      hjetsfinal->GetXaxis()->SetBinLabel(ibin,label);
       hbtags  ->GetXaxis()->SetBinLabel(ibin,label);
-  } 
+  }
 
   mon.addHistogram( new TH1F( "mindphijmet",  ";min #Delta#phi(jet,E_{T}^{miss});Events",20,0,4) );
   mon.addHistogram( new TH1F( "mindphijmet25",  ";min #Delta#phi(jet,E_{T}^{miss});Events",20,0,4) );
@@ -597,7 +597,7 @@ int main(int argc, char* argv[])
   mon.addHistogram( new TH1F( "mindphijmetfinal",  ";min #Delta#phi(jet,E_{T}^{miss});Events",20,0,4) );
   mon.addHistogram( new TH1F("vbfmjjfinal"       , ";Dijet invariant mass [GeV];Events / GeV",31,mjjaxis) );
   mon.addHistogram( new TH1F("vbfdetajjfinal"    , ";Pseudo-rapidity span;Events",20,0,10) );
-  
+
   mon.addHistogram( new TH1F( "mzz",   ";M_{ZZ} [GeV];Events / GeV", 150, 0, 1500) ); //The binning is the same than the one for the corrections.
 
 
@@ -618,9 +618,9 @@ int main(int argc, char* argv[])
   Hoptim_cuts->GetYaxis()->SetBinLabel(1, "met>");
   for(unsigned int index=0;index<optim_Cuts1_met.size();index++){ Hoptim_cuts    ->Fill(index, 0.0, optim_Cuts1_met[index]);  }
   for(size_t ivar=0; ivar<nvarsToInclude; ivar++){
-      for(unsigned int nri=0;nri<NRparams.size();nri++){ 
-	mon.addHistogram( new TH2F (TString("mt_shapes")+NRsuffix[nri]+varNames[ivar],";cut index;Transverse mass [GeV];Events",optim_Cuts1_met.size(),0,optim_Cuts1_met.size(), 385,150,3000) );     
-	mon.addHistogram( new TH2F (TString("met_shapes")+NRsuffix[nri]+varNames[ivar],";cut index;Missing transverse energy [GeV];Events",optim_Cuts1_met.size(),0,optim_Cuts1_met.size(),300 ,0,1500) );     
+      for(unsigned int nri=0;nri<NRparams.size();nri++){
+	mon.addHistogram( new TH2F (TString("mt_shapes")+NRsuffix[nri]+varNames[ivar],";cut index;Transverse mass [GeV];Events",optim_Cuts1_met.size(),0,optim_Cuts1_met.size(), 385,150,3000) );
+	mon.addHistogram( new TH2F (TString("met_shapes")+NRsuffix[nri]+varNames[ivar],";cut index;Missing transverse energy [GeV];Events",optim_Cuts1_met.size(),0,optim_Cuts1_met.size(),300 ,0,1500) );
 	TH2F *h=(TH2F *) mon.addHistogram( new TH2F ("mt_shapes_NRBctrl"+NRsuffix[nri]+varNames[ivar],";cut index;Selection region;Events",optim_Cuts1_met.size(),0,optim_Cuts1_met.size(),6,0,6) );
 
 	h->GetYaxis()->SetBinLabel(1,"M_{in}^{ll}/=0 b-tags");
@@ -632,14 +632,14 @@ int main(int argc, char* argv[])
       }
     }
 
-  std::vector<std::vector<double>> optim_Cuts_VBF; 
-  for(double jet2Pt=20    ;jet2Pt<50;jet2Pt+=5) { 
+  std::vector<std::vector<double>> optim_Cuts_VBF;
+  for(double jet2Pt=20    ;jet2Pt<50;jet2Pt+=5) {
      for(double jet1Pt=jet2Pt;jet1Pt<50;jet1Pt+=5) {
-        for(double deta=2.0     ;deta<5.0;deta+=0.25) { 
+        for(double deta=2.0     ;deta<5.0;deta+=0.25) {
            for(double mjj=100.0    ;mjj<1000;mjj+=50) {
               optim_Cuts_VBF.push_back( std::vector<double>{jet1Pt, jet2Pt, deta, mjj} );
   }}}}
-   
+
   TH2F* Hoptim_cuts_VBF  =(TH2F*)mon.addHistogram(new TProfile2D("optim_cut_VBF",      ";cut index;variable",       optim_Cuts_VBF.size(),0,optim_Cuts_VBF.size(), 4, 0, 4)) ;
   Hoptim_cuts_VBF->GetYaxis()->SetBinLabel(1, "jet1 p_{T}>");
   Hoptim_cuts_VBF->GetYaxis()->SetBinLabel(2, "jet2 p_{T}>");
@@ -648,10 +648,10 @@ int main(int argc, char* argv[])
   for(unsigned int index=0;index<optim_Cuts_VBF.size();index++){ for(unsigned int cut=0;cut<4;cut++){ Hoptim_cuts_VBF    ->Fill(index, float(cut), optim_Cuts_VBF[index][cut]); }  }
   for(size_t ivar=0; ivar<nvarsToInclude; ivar++){
      if(ivar>0)continue;// do not fill for systematics in order to save time
-     mon.addHistogram( new TH2F (TString("vbf_shapes")+varNames[ivar],";cut index;Transverse mass [GeV];Events",optim_Cuts_VBF.size(),0,optim_Cuts_VBF.size(), 1, 0, 2500) );     
+     mon.addHistogram( new TH2F (TString("vbf_shapes")+varNames[ivar],";cut index;Transverse mass [GeV];Events",optim_Cuts_VBF.size(),0,optim_Cuts_VBF.size(), 1, 0, 2500) );
   }
 
-     
+
   //##############################################
   //######## GET READY FOR THE EVENT LOOP ########
   //##############################################
@@ -665,15 +665,15 @@ int main(int argc, char* argv[])
   if (is2016MC || is2016data) { jecDir+="80X/"; }
 
   gSystem->ExpandPathName(jecDir);
-  
+
   FactorizedJetCorrector *jesCor = NULL;
   jesCor = utils::cmssw::getJetCorrector(jecDir,isMC);
 
   TString pf(isMC ? "MC" : "DATA");
   JetCorrectionUncertainty *totalJESUnc = NULL;
-  //if(isMC || is2015data) 
+  //if(isMC || is2015data)
   totalJESUnc = new JetCorrectionUncertainty((jecDir+"/"+pf+"_Uncertainty_AK4PFchs.txt").Data());
-  
+
   //muon energy scale and uncertainties
   TString muscleDir = runProcess.getParameter<std::string>("muscleDir");
   gSystem->ExpandPathName(muscleDir);
@@ -682,26 +682,26 @@ int main(int argc, char* argv[])
   rochcor2016* muCor2016 = NULL; //need to be updated for 2016
   if(is2016MC || is2016data) muCor2016 = new rochcor2016();  //replace the MuScleFitCorrector we used at run1
 
-  //photon and electron enerhy scale based on https://twiki.cern.ch/twiki/bin/viewauth/CMS/EGMSmearer    (adapted to the miniAOD/FWLite framework) 
+  //photon and electron enerhy scale based on https://twiki.cern.ch/twiki/bin/viewauth/CMS/EGMSmearer    (adapted to the miniAOD/FWLite framework)
 
   ElectronEnergyCalibratorRun2 ElectronEnCorrector;
   string EGammaEnergyCorrectionFile = "";
   PhotonEnergyCalibratorRun2 PhotonEnCorrector;
   EpCombinationTool theEpCombinationTool;
   if(is2015MC || is2015data){
-  	EGammaEnergyCorrectionFile = "EgammaAnalysis/ElectronTools/data/76X_16DecRereco_2015"; 
+  	EGammaEnergyCorrectionFile = "EgammaAnalysis/ElectronTools/data/76X_16DecRereco_2015";
   	PhotonEnCorrector = PhotonEnergyCalibratorRun2(isMC, false, EGammaEnergyCorrectionFile);
   	PhotonEnCorrector.initPrivateRng(new TRandom(1234));
-  	theEpCombinationTool.init((string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/weights/GBRForest_data_25ns.root").c_str(), "gedelectron_p4combination_25ns");  //got confirmation from Matteo Sani that this works for both data and MC 
+  	theEpCombinationTool.init((string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/weights/GBRForest_data_25ns.root").c_str(), "gedelectron_p4combination_25ns");  //got confirmation from Matteo Sani that this works for both data and MC
   	ElectronEnCorrector = ElectronEnergyCalibratorRun2(theEpCombinationTool, isMC, false, EGammaEnergyCorrectionFile);
   	ElectronEnCorrector.initPrivateRng(new TRandom(1234));
   }
   if(is2016MC || is2016data){
-  	string EleEnergyCorrectionFile = "UserCode/llvv_fwk/data/jec/80X_ichepV1_2016_ele"; 
-  	string PhoEnergyCorrectionFile = "UserCode/llvv_fwk/data/jec/80X_ichepV1_2016_pho"; 
+  	string EleEnergyCorrectionFile = "UserCode/llvv_fwk/data/jec/80X_ichepV1_2016_ele";
+  	string PhoEnergyCorrectionFile = "UserCode/llvv_fwk/data/jec/80X_ichepV1_2016_pho";
   	PhotonEnCorrector = PhotonEnergyCalibratorRun2(isMC, false, PhoEnergyCorrectionFile);
   	PhotonEnCorrector.initPrivateRng(new TRandom(1234));
-  	theEpCombinationTool.init((string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/weights/GBRForest_data_25ns.root").c_str(), "gedelectron_p4combination_25ns");  //got confirmation from Matteo Sani that this works for both data and MC 
+  	theEpCombinationTool.init((string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/weights/GBRForest_data_25ns.root").c_str(), "gedelectron_p4combination_25ns");  //got confirmation from Matteo Sani that this works for both data and MC
   	ElectronEnCorrector = ElectronEnergyCalibratorRun2(theEpCombinationTool, isMC, false, EleEnergyCorrectionFile);
   	ElectronEnCorrector.initPrivateRng(new TRandom(1234));
   }
@@ -743,8 +743,8 @@ int main(int argc, char* argv[])
   // from Btag SF and eff from https://indico.cern.ch/event/437675/#preview:1629681
   // beff = 0.747; sfb = 0.899; //for Loose WP  //sfb is not actually used as it's taken from btagCal
   //
-  beff = 0.836; sfb = 0.920; //for Loose WP  //sfb is from page 7 https://indico.cern.ch/event/557018/contributions/2246312/attachments/1310986/1961665/csvSF_rwt_July18th_2016.pdf 
-  leff = 0.139;  
+  beff = 0.836; sfb = 0.920; //for Loose WP  //sfb is from page 7 https://indico.cern.ch/event/557018/contributions/2246312/attachments/1310986/1961665/csvSF_rwt_July18th_2016.pdf
+  leff = 0.139;
 
   //pileup weighting
   edm::LumiReWeighting* LumiWeights = NULL;
@@ -769,20 +769,20 @@ int main(int argc, char* argv[])
           PuShifters=utils::cmssw::getPUshifters(dataPileupDistribution,0.05);
           utils::getPileupNormalization(mcPileupDistribution, PUNorm, LumiWeights, PuShifters);
   }
- 
+
   gROOT->cd();  //THIS LINE IS NEEDED TO MAKE SURE THAT HISTOGRAM INTERNALLY PRODUCED IN LumiReWeighting ARE NOT DESTROYED WHEN CLOSING THE FILE
 
 
   higgs::utils::EventCategory eventCategoryInst(higgs::utils::EventCategory::EXCLUSIVE2JETSVBF); //jet(0,>=1)+vbf binning
   patUtils::MetFilter metFilter;
-  if(!isMC){ 
+  if(!isMC){
     if(is2015data){
       metFilter.FillBadEvents(string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/MetFilter/DoubleEG_RunD/DoubleEG_csc2015.txt");
-      metFilter.FillBadEvents(string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/MetFilter/DoubleEG_RunD/DoubleEG_ecalscn1043093.txt"); 
+      metFilter.FillBadEvents(string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/MetFilter/DoubleEG_RunD/DoubleEG_ecalscn1043093.txt");
       metFilter.FillBadEvents(string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/MetFilter/DoubleMuon_RunD/DoubleMuon_csc2015.txt");
-      metFilter.FillBadEvents(string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/MetFilter/DoubleMuon_RunD/DoubleMuon_ecalscn1043093.txt"); 
+      metFilter.FillBadEvents(string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/MetFilter/DoubleMuon_RunD/DoubleMuon_ecalscn1043093.txt");
       metFilter.FillBadEvents(string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/MetFilter/MuonEG_RunD/MuonEG_csc2015.txt");
-      metFilter.FillBadEvents(string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/MetFilter/MuonEG_RunD/MuonEG_ecalscn1043093.txt"); 
+      metFilter.FillBadEvents(string(std::getenv("CMSSW_BASE"))+"/src/UserCode/llvv_fwk/data/MetFilter/MuonEG_RunD/MuonEG_ecalscn1043093.txt");
     }
     else if(is2016data){
 
@@ -797,7 +797,7 @@ int main(int argc, char* argv[])
   //loop on all the events
   //DuplicatesChecker duplicatesChecker;
   //int nDuplicates(0)
-  
+
   printf("Progressing Bar           :0%%       20%%       40%%       60%%       80%%       100%%\n");
   for(unsigned int f=0;f<urls.size();f++){
      TFile* file = TFile::Open(urls[f].c_str() );
@@ -805,7 +805,7 @@ int main(int argc, char* argv[])
      printf("Scanning the ntuple %2i/%2i :", (int)f+1, (int)urls.size());
      int iev=0;
      int treeStep(ev.size()/50);
-     for(ev.toBegin(); !ev.atEnd(); ++ev){ iev++; 
+     for(ev.toBegin(); !ev.atEnd(); ++ev){ iev++;
          if(iev%treeStep==0){printf(".");fflush(stdout);}
          float weight = xsecWeight;
          double puWeightUp = 1.0;
@@ -819,27 +819,27 @@ int main(int argc, char* argv[])
          if(!isMC && !goodLumiFilter.isGoodLumi(ev.eventAuxiliary().run(),ev.eventAuxiliary().luminosityBlock()))continue;
 
          reco::GenParticleCollection gen;
-         GenEventInfoProduct eventInfo;       
+         GenEventInfoProduct eventInfo;
           if(isMC){
             fwlite::Handle< reco::GenParticleCollection > genHandle;
             genHandle.getByLabel(ev, "prunedGenParticles");
             if(genHandle.isValid()){ gen = *genHandle;}
 
             fwlite::Handle< GenEventInfoProduct > genEventInfoHandle;
-            genEventInfoHandle.getByLabel(ev, "generator");        
+            genEventInfoHandle.getByLabel(ev, "generator");
             if(genEventInfoHandle.isValid()){ eventInfo = *genEventInfoHandle;}
 
             //WEIGHT for NLO negative interference
             //totalNumEvent+=eventInfo.weight();
-            weight *= eventInfo.weight(); 
-       
+            weight *= eventInfo.weight();
+
 
             //WEIGHT for Pileup
 	    int ngenITpu = 0;
 	    fwlite::Handle< std::vector<PileupSummaryInfo> > puInfoH;
             puInfoH.getByLabel(ev, "slimmedAddPileupInfo");
             for(std::vector<PileupSummaryInfo>::const_iterator it = puInfoH->begin(); it != puInfoH->end(); it++){
-               if(it->getBunchCrossing()==0)      { ngenITpu += it->getTrueNumInteractions(); } //getPU_NumInteractions(); 
+               if(it->getBunchCrossing()==0)      { ngenITpu += it->getTrueNumInteractions(); } //getPU_NumInteractions();
             }
             puWeight          = LumiWeights->weight(ngenITpu) * PUNorm[0];
             puWeightUp  = PuShifters[utils::cmssw::PUUP  ]->Eval(ngenITpu) * (PUNorm[2]/PUNorm[0]);
@@ -848,8 +848,8 @@ int main(int argc, char* argv[])
 
             if(isMC && (mctruthmode==15 || mctruthmode==1113)){// && (string(dtag.Data()).find("Z#rightarrow")==0 || isMC_ZZ2l2nu))
                 int prodId = 1;
-                for( unsigned int k=0; k<gen.size(); ++k){	
-                        if( gen[k].isHardProcess() && ( abs( gen[k].pdgId() ) == 11 || abs( gen[k].pdgId() ) == 13 || abs( gen[k].pdgId() )==15 ) ) prodId*=gen[k].pdgId(); 
+                for( unsigned int k=0; k<gen.size(); ++k){
+                        if( gen[k].isHardProcess() && ( abs( gen[k].pdgId() ) == 11 || abs( gen[k].pdgId() ) == 13 || abs( gen[k].pdgId() )==15 ) ) prodId*=gen[k].pdgId();
                 }
                 if(mctruthmode==15   && abs(prodId)!=225)continue; //skip not tautau
                 if(mctruthmode==1113 && abs(prodId)==225)continue; //skip tautau
@@ -865,38 +865,38 @@ int main(int argc, char* argv[])
 	         if( isMC_125OnShell && higgs.mass()> 180) continue;
 	         if(!isMC_125OnShell && higgs.mass()<=180) continue;
 	       }
-	 
-               //Line shape weights 
-               if(isMC_VBF || isMC_GG || isMC_ggZZ2mu2nu || isMC_ggZZ2e2nu ){    
 
-               	  mon.fillHisto("higgsMass_raw",    "all", higgs.mass(), weight);          
-      
+               //Line shape weights
+               if(isMC_VBF || isMC_GG || isMC_ggZZ2mu2nu || isMC_ggZZ2e2nu ){
+
+               	  mon.fillHisto("higgsMass_raw",    "all", higgs.mass(), weight);
+
 		  //Apply NNLO kFactors to ggZZ2l2v or ggHZZ2l2v
-                  if(isMC_GG || isMC_ggZZ2mu2nu || isMC_ggZZ2e2nu){ nnlo_ggH_kFact=HNNLO_Wgt_Gr->Eval(higgs.mass()); 
+                  if(isMC_GG || isMC_ggZZ2mu2nu || isMC_ggZZ2e2nu){ nnlo_ggH_kFact=HNNLO_Wgt_Gr->Eval(higgs.mass());
 		  }else{ nnlo_ggH_kFact=1.0;}
-		  
-                  weight *= nnlo_ggH_kFact; 
+
+                  weight *= nnlo_ggH_kFact;
 		  mon.fillHisto("higgsMass_nnlo_raw",  "all", higgs.mass(), weight);
 
                   //WEIGHT for LineShape (NNLO kFactors + Interf), split in shape and scale unc with the following format:  scaleNominal, shapeNominal, scaleDown, shapeDown, scaleUp, shapeUp
                   //compute weight correction for all NR shapes
-                  for(unsigned int nri=0;nri<NRparams.size();nri++){ 
+                  for(unsigned int nri=0;nri<NRparams.size();nri++){
                      std::vector<std::pair<double, TGraph*> > shapeWgtGr = hLineShapeGrVec[NRparams[nri] ];
-                     if(!isMELA){     
-			for(size_t iwgt=0; iwgt<shapeWgtGr.size(); iwgt++){ 
+                     if(!isMELA){
+			for(size_t iwgt=0; iwgt<shapeWgtGr.size(); iwgt++){
                         	lShapeWeights[nri][iwgt*2+0]=shapeWgtGr[iwgt].first;
                         	lShapeWeights[nri][iwgt*2+1]=shapeWgtGr[iwgt].second?shapeWgtGr[iwgt].second->Eval(higgs.mass()):1.0;
                     	 }
 		     }else if(isMELA){
-			//printf("MelaMode: %s CPrime: %5.3f MPole: %5f \n", MelaMode.c_str(), NRparams[nri].first, resonance);	
+			//printf("MelaMode: %s CPrime: %5.3f MPole: %5f \n", MelaMode.c_str(), NRparams[nri].first, resonance);
                         lMelaShapeWeights[nri][MelaMode] = higgs::utils::weightNarrowResonnance_MELA( mela, isMC_VBF, MelaMode, NRparams[nri].first, resonance, ev);
 		     }
-                     
+
 		     double shape_SF =0; double shapescale_SF = 0;
 		     if( !isMELA ){ shape_SF = lShapeWeights[nri][1]; shapescale_SF = lShapeWeights[nri][0]; }
 		     else if( isMELA ){ shape_SF = lMelaShapeWeights[nri][MelaMode]; shapescale_SF = lMelaShapeWeights[nri][MelaMode]; }
- 
-		     mon.fillHisto(TString("MELA_weights"         )+NRsuffix[nri], "all",            1, shape_SF);   
+
+		     mon.fillHisto(TString("MELA_weights"         )+NRsuffix[nri], "all",            1, shape_SF);
                      mon.fillHisto(TString("higgsMass_shape"      )+NRsuffix[nri], "all", higgs.mass(), weight*shape_SF );
                      mon.fillHisto(TString("higgsMass_shape&scale")+NRsuffix[nri], "all", higgs.mass(), weight*shapescale_SF );
 
@@ -905,9 +905,9 @@ int main(int argc, char* argv[])
                      if(lShapeWeights[nri][1]>0){lShapeWeights[nri][3]/=lShapeWeights[nri][1];  lShapeWeights[nri][5]/=lShapeWeights[nri][1];}
 
                      //printf("NRI AW=%i --> %6.2e %6.2e %6.2e %6.2e %6.2e %6.2e\n", nri, lShapeWeights[nri][0], lShapeWeights[nri][1], lShapeWeights[nri][2], lShapeWeights[nri][3], lShapeWeights[nri][4], lShapeWeights[nri][5]);
-                  }  
+                  }
                   if(!isMELA){ weight *= lShapeWeights[0][0]*lShapeWeights[0][1]; }
-		  else if(isMELA){ weight *= lMelaShapeWeights[0][MelaMode]; }  
+		  else if(isMELA){ weight *= lMelaShapeWeights[0][MelaMode]; }
 	      }
             }
           }
@@ -931,53 +931,53 @@ int main(int argc, char* argv[])
           float triggerPrescale(1.0),triggerThreshold(0), triggerThresholdHigh(99999);
           char photonTriggerTreshName[255];
 
-	  bool mumuTrigger(true); bool muTrigger(true);	bool eeTrigger(true); bool eTrigger(true); bool emuTrigger(true); 
-	  bool photonTrigger(true);                                                                                         
-  
-          int metFilterValue = 0;                                                                   
+	  bool mumuTrigger(true); bool muTrigger(true);	bool eeTrigger(true); bool eTrigger(true); bool emuTrigger(true);
+	  bool photonTrigger(true);
 
-	  bool filterbadPFMuon = true; 
+          int metFilterValue = 0;
+
+	  bool filterbadPFMuon = true;
 	  bool filterbadChCandidate = true;
 	  bool filterbadMuonHIP = true;
 	  bool filterduplicateMuonHIP = true;
 	  std::unique_ptr<std::vector<reco::Muon*>> outbadMuon(new std::vector<reco::Muon*>());
-	  std::unique_ptr<std::vector<reco::Muon*>> outduplicateMuon(new std::vector<reco::Muon*>());                                                                                                                                                             
+	  std::unique_ptr<std::vector<reco::Muon*>> outduplicateMuon(new std::vector<reco::Muon*>());
           if (is2016data || is2016MC) {
-                                    
+
 	    //	    if (!is2016MC) { // Trigger not applied in MC
 	    if (!isOldMC) {
 
-	      mumuTrigger        = utils::passTriggerPatterns(tr, "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*", "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*", "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*" , "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*");        
+	      mumuTrigger        = utils::passTriggerPatterns(tr, "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*", "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*", "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*" , "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*");
 	      muTrigger          = utils::passTriggerPatterns(tr, "HLT_IsoMu22_v*","HLT_IsoTkMu22_v*", "HLT_IsoMu24_v*", "HLT_IsoTkMu24_v*");
-	      eeTrigger          = utils::passTriggerPatterns(tr, "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*","HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*");        
+	      eeTrigger          = utils::passTriggerPatterns(tr, "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*","HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*");
 	      eTrigger           = utils::passTriggerPatterns(tr, "HLT_Ele27_eta2p1_WPLoose_Gsf_v*","HLT_Ele27_WPTight_Gsf_v*") ;
 	      emuTrigger         = utils::passTriggerPatterns(tr, "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*","HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*","HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*" , "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*") || utils::passTriggerPatterns(tr,"HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*","HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*");
 	      photonTrigger      = ( patUtils::passPhotonTrigger(ev, triggerThreshold, triggerPrescale, triggerThresholdHigh) ||
-				     patUtils::passVBFPhotonTrigger(ev, triggerThreshold, triggerPrescale, triggerThresholdHigh) );                                                     
+				     patUtils::passVBFPhotonTrigger(ev, triggerThreshold, triggerPrescale, triggerThresholdHigh) );
 	    }
-                                                                                                               
-	    metFilterValue = metFilter.passMetFilterInt( ev, is2016data );                                                                                                     
-	    
-	    // Apply Bad Charged Hadron and Bad Muon Filters from MiniAOD (for Run II 2016 only ) 
-	    filterbadChCandidate = metFilter.passBadChargedCandidateFilter(ev); if (!filterbadChCandidate) {  metFilterValue=9; } 
+
+	    metFilterValue = metFilter.passMetFilterInt( ev, is2016data );
+
+	    // Apply Bad Charged Hadron and Bad Muon Filters from MiniAOD (for Run II 2016 only )
+	    filterbadChCandidate = metFilter.passBadChargedCandidateFilter(ev); if (!filterbadChCandidate) {  metFilterValue=9; }
 	    filterbadPFMuon = metFilter.passBadPFMuonFilter(ev); if (!filterbadPFMuon) { metFilterValue=8; }
 	    filterbadMuonHIP = metFilter.BadGlobalMuonTaggerFilter(ev,outbadMuon,false); if (!filterbadMuonHIP) { metFilterValue=10; }
 	    filterduplicateMuonHIP = metFilter.BadGlobalMuonTaggerFilter(ev,outduplicateMuon,true); if (!filterduplicateMuonHIP) { metFilterValue=11; }
-	                                                                                                                                              
-          } else {    
 
-            mumuTrigger        = utils::passTriggerPatterns(tr, "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*", "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*");                         
-            muTrigger          = utils::passTriggerPatterns(tr, "HLT_IsoMu20_v*", "HLT_IsoTkMu20_v*", "HLT_IsoMu27_v*");                                                       
-            eeTrigger          = utils::passTriggerPatterns(tr, "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*","HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*");                
-            eTrigger           = utils::passTriggerPatterns(tr, "HLT_Ele23_WPLoose_Gsf_v*", "HLT_Ele22_eta2p1_WP75_Gsf_v*", "HLT_Ele22_eta2p1_WPLoose_Gsf_v*");                
-            emuTrigger         = utils::passTriggerPatterns(tr, "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*",                                                           
-                                                            "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*");                                                             
+          } else {
 
-            photonTrigger      = patUtils::passPhotonTrigger(ev, triggerThreshold, triggerPrescale, triggerThresholdHigh);                                                                                                                                                                                                              
-            metFilterValue = metFilter.passMetFilterInt( ev );                                                                                                                 
-          }                                                                                                                                                                    
-	 
-          mon.fillHisto("metFilter_eventflow", "", metFilterValue, weight);   
+            mumuTrigger        = utils::passTriggerPatterns(tr, "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*", "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*");
+            muTrigger          = utils::passTriggerPatterns(tr, "HLT_IsoMu20_v*", "HLT_IsoTkMu20_v*", "HLT_IsoMu27_v*");
+            eeTrigger          = utils::passTriggerPatterns(tr, "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*","HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*");
+            eTrigger           = utils::passTriggerPatterns(tr, "HLT_Ele23_WPLoose_Gsf_v*", "HLT_Ele22_eta2p1_WP75_Gsf_v*", "HLT_Ele22_eta2p1_WPLoose_Gsf_v*");
+            emuTrigger         = utils::passTriggerPatterns(tr, "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*",
+                                                            "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*");
+
+            photonTrigger      = patUtils::passPhotonTrigger(ev, triggerThreshold, triggerPrescale, triggerThresholdHigh);
+            metFilterValue = metFilter.passMetFilterInt( ev );
+          }
+
+          mon.fillHisto("metFilter_eventflow", "", metFilterValue, weight);
 
           bool passTrigger        = mumuTrigger||muTrigger||eeTrigger||eTrigger||emuTrigger||photonTrigger;
 
@@ -1010,19 +1010,19 @@ int main(int argc, char* argv[])
 
 
           //ONLY RUN ON THE EVENTS THAT PASS OUR TRIGGERS
-	  if(!passTrigger && !photonTriggerStudy)continue;        
+	  if(!passTrigger && !photonTriggerStudy)continue;
          //##############################################   EVENT PASSED THE TRIGGER   ######################################
 	  if (metFilterValue==10 || metFilterValue==11) { metFilterValue=0; }
           if( metFilterValue!=0 ) continue;	 //Note this must also be applied on MC
 
 	  // Apply Bad Charged Hadron and Bad Muon Filters from MiniAOD (for Run II 2016 only )
 	  //	  if (!filterbadPFMuon || !filterbadChCandidate) continue;
-          //##############################################   EVENT PASSED MET FILTER   ####################################### 
+          //##############################################   EVENT PASSED MET FILTER   #######################################
 
 
           //load all the objects we will need to access
           reco::VertexCollection vtx;
-          fwlite::Handle< reco::VertexCollection > vtxHandle; 
+          fwlite::Handle< reco::VertexCollection > vtxHandle;
           vtxHandle.getByLabel(ev, "offlineSlimmedPrimaryVertices");
           if(vtxHandle.isValid()){ vtx = *vtxHandle;}
 
@@ -1050,18 +1050,21 @@ int main(int argc, char* argv[])
           fwlite::Handle< pat::PhotonCollection > photonsHandle;
           photonsHandle.getByLabel(ev, "slimmedPhotons");
           if(photonsHandle.isValid()){ photons = *photonsHandle;}
-          
+
           pat::METCollection mets;
           fwlite::Handle< pat::METCollection > metsHandle;
           metsHandle.getByLabel(ev, "slimmedMETs");
           if(metsHandle.isValid()){ mets = *metsHandle;}
-          pat::MET met = mets[0]; 
+          pat::MET met = mets[0];
 
           pat::METCollection puppimets;
           fwlite::Handle< pat::METCollection > puppimetsHandle;
           puppimetsHandle.getByLabel(ev, "slimmedMETsPuppi");
           if(puppimetsHandle.isValid()){ puppimets = *puppimetsHandle;}
-          LorentzVector puppimet = puppimets[0].p4(); 
+          LorentzVector puppimet = puppimets[0].p4();
+
+          fwlite::Handle<pat::PackedCandidateCollection> PFparticles;
+          PFparticles.getByLabel(ev, "packedPFCandidates");
 
     			//GenJets
 			    reco::GenJetCollection genJets;
@@ -1118,11 +1121,11 @@ int main(int argc, char* argv[])
 
          //Resolve G+jet/QCD mixing (avoid double counting of photons)
          if (isMC_GJet || isMC_QCD ) {
-           // iF GJet sample; accept only event with prompt photons                                                                 
-           // if QCD sample; reject events with prompt photons in final state                                                       
+           // iF GJet sample; accept only event with prompt photons
+           // if QCD sample; reject events with prompt photons in final state
              bool gPromptFound=false;
              for(size_t ig=0; ig<gen.size(); ig++){
-               if((abs(gen[ig].pdgId())==22) && gen[ig].isPromptFinalState())  gPromptFound=true;               
+               if((abs(gen[ig].pdgId())==22) && gen[ig].isPromptFinalState())  gPromptFound=true;
              }
              if ( (isMC_GJet) && (!gPromptFound) ) continue; //reject event
              if ( (isMC_QCD) && gPromptFound ) continue; //reject event
@@ -1134,15 +1137,15 @@ int main(int argc, char* argv[])
      	 if(isMC_ZZ2l2nu || isMC_WZ3lnu) ewkCorrectionsWeight = EwkCorrections::getEwkCorrections(dtag, gen, ewkTable, eventInfo, ewkCorrections_error);
      	 double ewkCorrections_up = (ewkCorrectionsWeight + ewkCorrections_error)/ewkCorrectionsWeight;
          double ewkCorrections_down = (ewkCorrectionsWeight - ewkCorrections_error)/ewkCorrectionsWeight;
-     
+
        	 //final event weight
        	 weight *= ewkCorrectionsWeight;
-    
+
     	 //NNLO corrections on ZZ2l2nu
     	 double ZZ_NNLOcorrectionsWeight =1.;
-	 double mzz = - 404; // will be filled by getNNLOCorrections 
+	 double mzz = - 404; // will be filled by getNNLOCorrections
 	 if(isMC_ZZ2l2nu) ZZ_NNLOcorrectionsWeight = ZZatNNLO::getNNLOCorrections(dtag, gen, ZZ_NNLOTable, mzz);
-				 
+
 	 //final event weight
 	 if(isMC_ZZ2l2nu) mon.fillHisto("mzz", "qqZZ_atNLO", mzz, weight);
 	 weight *= ZZ_NNLOcorrectionsWeight;
@@ -1157,11 +1160,11 @@ int main(int argc, char* argv[])
          //
          // LEPTON ANALYSIS
          //
-         
+
          //start by merging electrons and muons
          std::vector<patUtils::GenericLepton> leptons;
-         for(size_t l=0;l<electrons.size();l++){leptons.push_back(patUtils::GenericLepton(electrons[l]));}      
-         for(size_t l=0;l<muons    .size();l++){leptons.push_back(patUtils::GenericLepton(muons    [l]));}      
+         for(size_t l=0;l<electrons.size();l++){leptons.push_back(patUtils::GenericLepton(electrons[l]));}
+         for(size_t l=0;l<muons    .size();l++){leptons.push_back(patUtils::GenericLepton(muons    [l]));}
          std::sort(leptons.begin(),   leptons.end(), utils::sort_CandidatesByPt);
 
          std::vector<patUtils::GenericLepton> selLeptons, extraLeptons;
@@ -1176,15 +1179,18 @@ int main(int argc, char* argv[])
              lid=abs(lid);
              TString lepStr( lid==13 ? "mu" : "e");
 
+             reco::Vertex& vertex = vtx[0];
+             std::vector<pat::PackedCandidate> PFpartVect = *PFparticles;
+
              //Cut based identification
              if(is2016MC || is2016data){
-                 passId = lid==11?patUtils::passId(leptons[ilep].el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::ICHEP16Cut) : patUtils::passId(leptons[ilep].mu, vtx[0], patUtils::llvvMuonId::Tight, patUtils::CutVersion::ICHEP16Cut);
+                 passId = lid==11?patUtils::passId(leptons[ilep].el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::ICHEP16Cut) : patUtils::passId(leptons[ilep].mu, vtx[0], patUtils::llvvMuonId::tkHighPT, patUtils::CutVersion::ICHEP16Cut);
                  passLooseLepton &= lid==11?patUtils::passId(leptons[ilep].el, vtx[0], patUtils::llvvElecId::Loose, patUtils::CutVersion::ICHEP16Cut) : patUtils::passId(leptons[ilep].mu, vtx[0], patUtils::llvvMuonId::Loose, patUtils::CutVersion::ICHEP16Cut);
                  passSoftMuon &= lid==11? false : patUtils::passId(leptons[ilep].mu, vtx[0], patUtils::llvvMuonId::Soft, patUtils::CutVersion::ICHEP16Cut);
 
                  //isolation
                  //passIso = lid==11?patUtils::passIso(leptons[ilep].el,  patUtils::llvvElecIso::Tight, patUtils::CutVersion::ICHEP16Cut, 0) : patUtils::passIso(leptons[ilep].mu,  patUtils::llvvMuonIso::Tight, patUtils::CutVersion::ICHEP16Cut);
-                 passIso = lid==11?patUtils::passIso(leptons[ilep].el,  patUtils::llvvElecIso::Tight, patUtils::CutVersion::ICHEP16Cut, 0) :   patUtils::passIso(leptons[ilep].mu,  patUtils::llvvMuonIso::Tight, patUtils::CutVersion::ICHEP16Cut);
+                 passIso = lid==11?patUtils::passIso(leptons[ilep].el,  patUtils::llvvElecIso::Tight, patUtils::CutVersion::ICHEP16Cut, 0) :   patUtils::passIso(leptons[ilep].mu,  patUtils::llvvMuonIso::TightAndTkRelatBoosted, patUtils::CutVersion::Moriond17Cut, PFpartVect, muons, vertex);
                  passLooseLepton &= lid==11?patUtils::passIso(leptons[ilep].el,  patUtils::llvvElecIso::Loose, patUtils::CutVersion::ICHEP16Cut, 0) : patUtils::passIso(leptons[ilep].mu,  patUtils::llvvMuonIso::Loose, patUtils::CutVersion::ICHEP16Cut);
 	     } else {
                  passId = lid==11?patUtils::passId(leptons[ilep].el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::Spring15Cut25ns) : patUtils::passId(leptons[ilep].mu, vtx[0], patUtils::llvvMuonId::Tight, patUtils::CutVersion::Spring15Cut25ns);
@@ -1236,14 +1242,14 @@ int main(int argc, char* argv[])
                  }
                }
 
-             //apply electron corrections             
+             //apply electron corrections
              if(abs(lid)==11  && passIso && passId){
-                elDiff -= leptons[ilep].p4();                   
+                elDiff -= leptons[ilep].p4();
                 if (isMC || is2015data || is2016data){
-                	ElectronEnCorrector.calibrate(leptons[ilep].el, ev.eventAuxiliary().run(), edm::StreamID::invalidStreamID()); 
+                	ElectronEnCorrector.calibrate(leptons[ilep].el, ev.eventAuxiliary().run(), edm::StreamID::invalidStreamID());
                 	leptons[ilep] = patUtils::GenericLepton(leptons[ilep].el); //recreate the generic lepton to be sure that the p4 is ok
                 }
-                elDiff += leptons[ilep].p4();                 
+                elDiff += leptons[ilep].p4();
              }
 
               //kinematics
@@ -1259,8 +1265,8 @@ int main(int argc, char* argv[])
                if(leptons[ilep].pt()<10) passLooseLepton=false;
              }
              if(leptons[ilep].pt()<25) passKin=false;
-            
-             if(passId && passIso && passKin)          selLeptons.push_back(leptons[ilep]); 
+
+             if(passId && passIso && passKin)          selLeptons.push_back(leptons[ilep]);
              else if(passLooseLepton || passSoftMuon)  extraLeptons.push_back(leptons[ilep]);
 
          }
@@ -1279,7 +1285,7 @@ int main(int argc, char* argv[])
             if(photonTrigger && (photon.pt()<(triggerThreshold) || photon.pt()>(triggerThresholdHigh+10)))continue;
 
 	    //Calibrate photon energy
-	    PhotonEnCorrector.calibrate(photon, ev.eventAuxiliary().run(), edm::StreamID::invalidStreamID()); 
+	    PhotonEnCorrector.calibrate(photon, ev.eventAuxiliary().run(), edm::StreamID::invalidStreamID());
 
 	    //Removed all the phtons which are alsp reconstructed ad Electron and muons
             double minDRlg(9999.);
@@ -1297,7 +1303,7 @@ int main(int argc, char* argv[])
             if(photon.pt()>100)nPho100++;
 
            }
-	  
+
            std::sort(selLeptons.begin(),   selLeptons.end(), utils::sort_CandidatesByPt);
            std::sort(extraLeptons.begin(), extraLeptons.end(), utils::sort_CandidatesByPt);
 
@@ -1312,14 +1318,14 @@ int main(int argc, char* argv[])
       	  double minDRlj(9999.); for(size_t ilep=0; ilep<selLeptons.size(); ilep++)  minDRlj = TMath::Min( minDRlj, deltaR(genJets[ig],selLeptons[ilep]) );
       	  double minDRlg(9999.); for(size_t ipho=0; ipho<selPhotons.size(); ipho++)  minDRlg = TMath::Min( minDRlg, deltaR(genJets[ig],selPhotons[ipho]) );
       	  if(minDRlj<0.4 || minDRlg<0.4) continue;
-	
+
 	        vHT += genJets[ig].pt();
 	      }
 	      if(vHT >100) isHT100 = true;
-	
+
 	      if(isMC_Wlnu_inclusive && isHT100) continue; //reject event
 	      if(isMC_Wlnu_HT100 && !isHT100) continue; //reject event
-	
+
 	    }
 
 
@@ -1331,12 +1337,12 @@ int main(int argc, char* argv[])
            met.setUncShift(met.px() + muDiff.px()*0.01, met.py() + muDiff.py()*0.01, met.sumEt() + muDiff.pt()*0.01, pat::MET::METUncertainty::MuonEnDown); //assume 1% uncertainty on muon rochester
            met.setUncShift(met.px() - elDiff.px()*0.01, met.py() - elDiff.py()*0.01, met.sumEt() - elDiff.pt()*0.01, pat::MET::METUncertainty::ElectronEnUp);   //assume 1% uncertainty on electron scale correction
            met.setUncShift(met.px() + elDiff.px()*0.01, met.py() + elDiff.py()*0.01, met.sumEt() + elDiff.pt()*0.01, pat::MET::METUncertainty::ElectronEnDown); //assume 1% uncertainty on electron scale correction
- 
+
          //
          //JET/MET ANALYSIS
          //
-         //add scale/resolution uncertainties and propagate to the MET      
-         if(isMC || is2015data) utils::cmssw::updateJEC(jets,jesCor,totalJESUnc,rho,vtx.size(),isMC); 
+         //add scale/resolution uncertainties and propagate to the MET
+         if(isMC || is2015data) utils::cmssw::updateJEC(jets,jesCor,totalJESUnc,rho,vtx.size(),isMC);
 
          //select the jets
          std::map<string, pat::JetCollection> selJetsVar;
@@ -1355,12 +1361,12 @@ int main(int argc, char* argv[])
              //mc truth for this jet
              const reco::GenJet* genJet=jet.genJet();
              TString jetType( genJet && genJet->pt()>0 ? "truejetsid" : "pujetsid" );
-             
+
              //cross-clean with selected leptons and photons
              double minDRlj(9999.); for(size_t ilep=0; ilep<selLeptons.size(); ilep++)  minDRlj = TMath::Min( minDRlj, deltaR(jet,selLeptons[ilep]) );
              double minDRlg(9999.); for(size_t ipho=0; ipho<selPhotons.size(); ipho++)  minDRlg = TMath::Min( minDRlg, deltaR(jet,selPhotons[ipho]) );
              if(minDRlj<0.4 || minDRlg<0.4) continue;
-             
+
              //jet id
              bool passPFloose = patUtils::passPFJetID("Loose", jet);
              bool passLooseSimplePuId = true; //patUtils::passPUJetID(jet); //FIXME Broken in miniAOD V2 : waiting for JetMET fix. (Hugo)
@@ -1370,19 +1376,19 @@ int main(int argc, char* argv[])
                  if(passLooseSimplePuId)                mon.fillHisto("jetId", jetType,fabs(jet.eta()),2);
                  if(passPFloose && passLooseSimplePuId) mon.fillHisto("jetId", jetType,fabs(jet.eta()),3);
              }
-             if(!passPFloose || !passLooseSimplePuId) continue; 
+             if(!passPFloose || !passLooseSimplePuId) continue;
 
 
             //check for btagging
             if(jet.pt()>30 && fabs(jet.eta())<2.5){
               bool hasCSVtag = (jet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags")>btagLoose);
-              bool hasCSVtagUp = hasCSVtag;  
+              bool hasCSVtagUp = hasCSVtag;
               bool hasCSVtagDown = hasCSVtag;
               //update according to the SF measured by BTV
               if(isMC){
                   int flavId=jet.partonFlavour();  double eta=jet.eta();
 		  btsfutil.SetSeed(ev.eventAuxiliary().event()*10 + ijet*10000);
-                  if      (abs(flavId)==5){  
+                  if      (abs(flavId)==5){
 					//  74X recommendation
 					//     btsfutil.modifyBTagsWithSF(hasCSVtag    , btagCal   .eval(BTagEntry::FLAV_B   , eta, jet.pt()), beff);
                                         //     btsfutil.modifyBTagsWithSF(hasCSVtagUp  , btagCalUp .eval(BTagEntry::FLAV_B   , eta, jet.pt()), beff);
@@ -1391,7 +1397,7 @@ int main(int argc, char* argv[])
                                         btsfutil.modifyBTagsWithSF(hasCSVtag    , btagCal80X.eval_auto_bounds("central", BTagEntry::FLAV_B   , eta, jet.pt()), beff);
                                         btsfutil.modifyBTagsWithSF(hasCSVtagUp  , btagCal80X.eval_auto_bounds("up", BTagEntry::FLAV_B   , eta, jet.pt()), beff);
                                         btsfutil.modifyBTagsWithSF(hasCSVtagDown, btagCal80X.eval_auto_bounds("down", BTagEntry::FLAV_B   , eta, jet.pt()), beff);
-                  }else if(abs(flavId)==4){  
+                  }else if(abs(flavId)==4){
 					//  74X recommendation
 					//     btsfutil.modifyBTagsWithSF(hasCSVtag    , btagCal   .eval(BTagEntry::FLAV_C   , eta, jet.pt()), beff);
 					//     btsfutil.modifyBTagsWithSF(hasCSVtagUp  , btagCalUp .eval(BTagEntry::FLAV_C   , eta, jet.pt()), beff);
@@ -1400,8 +1406,8 @@ int main(int argc, char* argv[])
 			                btsfutil.modifyBTagsWithSF(hasCSVtag    , btagCal80X.eval_auto_bounds("central", BTagEntry::FLAV_C   , eta, jet.pt()), beff);
                                         btsfutil.modifyBTagsWithSF(hasCSVtagUp  , btagCal80X.eval_auto_bounds("up", BTagEntry::FLAV_C   , eta, jet.pt()), beff);
                                         btsfutil.modifyBTagsWithSF(hasCSVtagDown, btagCal80X.eval_auto_bounds("down", BTagEntry::FLAV_C   , eta, jet.pt()), beff);
-                  }else{                
-					//  74X recommendation 
+                  }else{
+					//  74X recommendation
 					//     btsfutil.modifyBTagsWithSF(hasCSVtag    , btagCalL  .eval(BTagEntry::FLAV_UDSG, eta, jet.pt()), leff);
                                         //     btsfutil.modifyBTagsWithSF(hasCSVtagUp  , btagCalLUp.eval(BTagEntry::FLAV_UDSG, eta, jet.pt()), leff);
                                         //     btsfutil.modifyBTagsWithSF(hasCSVtagDown, btagCalLDn.eval(BTagEntry::FLAV_UDSG, eta, jet.pt()), leff);
@@ -1441,7 +1447,7 @@ int main(int argc, char* argv[])
          double initialWeight = weight;
 
          //compute scale uncertainty once and for all
-         std::pair<double, double> scaleUncVar = patUtils::scaleVariation(ev);  //compute it only once          
+         std::pair<double, double> scaleUncVar = patUtils::scaleVariation(ev);  //compute it only once
 
          // LOOP ON SYSTEMATIC VARIATION FOR THE STATISTICAL ANALYSIS
          for(size_t ivar=0; ivar<nvarsToInclude; ivar++){
@@ -1451,7 +1457,7 @@ int main(int argc, char* argv[])
           float weight = initialWeight;
 
            //Theoretical Uncertanties: PDF, Alpha and Scale
-           if(varNames[ivar]=="_th_factup")     weight *= std::max(0.9, std::min(scaleUncVar.first , 1.1)); 
+           if(varNames[ivar]=="_th_factup")     weight *= std::max(0.9, std::min(scaleUncVar.first , 1.1));
            if(varNames[ivar]=="_th_factdown")   weight *= std::max(0.9, std::min(scaleUncVar.second, 1.1));
            if(varNames[ivar]=="_th_alphas")     weight *= patUtils::alphaVariation(ev);
            if(varNames[ivar]=="_th_pdf")        weight *= patUtils::pdfVariation(ev);
@@ -1463,21 +1469,21 @@ int main(int argc, char* argv[])
            //pileup variations
            if(varNames[ivar]=="_puup")          weight *= puWeightUp;
            if(varNames[ivar]=="_pudown")        weight *= puWeightDown;
-          
+
            //recompute MET with variation
            LorentzVector imet = met.corP4(metcor);
            if(varNames[ivar]=="_scale_jup")      imet = met.shiftedP4(pat::MET::METUncertainty::JetEnUp           , metcor);
            if(varNames[ivar]=="_scale_jdown")    imet = met.shiftedP4(pat::MET::METUncertainty::JetEnDown         , metcor);
            if(varNames[ivar]=="_res_jup")        imet = met.shiftedP4(pat::MET::METUncertainty::JetResUp          , metcor);
            if(varNames[ivar]=="_res_jdown")      imet = met.shiftedP4(pat::MET::METUncertainty::JetResDown        , metcor);
-           if(varNames[ivar]=="_scale_umetup")   imet = met.shiftedP4(pat::MET::METUncertainty::UnclusteredEnUp   , metcor);              
-           if(varNames[ivar]=="_scale_umetdown") imet = met.shiftedP4(pat::MET::METUncertainty::UnclusteredEnDown , metcor);              
+           if(varNames[ivar]=="_scale_umetup")   imet = met.shiftedP4(pat::MET::METUncertainty::UnclusteredEnUp   , metcor);
+           if(varNames[ivar]=="_scale_umetdown") imet = met.shiftedP4(pat::MET::METUncertainty::UnclusteredEnDown , metcor);
            if(varNames[ivar]=="_scale_mup")      imet = met.shiftedP4(pat::MET::METUncertainty::MuonEnUp          , metcor);
-           if(varNames[ivar]=="_scale_mdown")    imet = met.shiftedP4(pat::MET::METUncertainty::MuonEnDown        , metcor);             
-           if(varNames[ivar]=="_scale_eup")      imet = met.shiftedP4(pat::MET::METUncertainty::ElectronEnUp      , metcor); 
+           if(varNames[ivar]=="_scale_mdown")    imet = met.shiftedP4(pat::MET::METUncertainty::MuonEnDown        , metcor);
+           if(varNames[ivar]=="_scale_eup")      imet = met.shiftedP4(pat::MET::METUncertainty::ElectronEnUp      , metcor);
            if(varNames[ivar]=="_scale_edown")    imet = met.shiftedP4(pat::MET::METUncertainty::ElectronEnDown    , metcor);
 
-           auto& selJets      = selJetsVar[""];        if(selJetsVar    .find(varNames[ivar].Data())!=selJetsVar    .end())selJets     = selJetsVar    [varNames[ivar].Data()];            
+           auto& selJets      = selJetsVar[""];        if(selJetsVar    .find(varNames[ivar].Data())!=selJetsVar    .end())selJets     = selJetsVar    [varNames[ivar].Data()];
            auto& njets        = njetsVar [""];         if(njetsVar      .find(varNames[ivar].Data())!=njetsVar      .end())njets       = njetsVar      [varNames[ivar].Data()];
            auto& nbtags       = nbtagsVar[""];         if(nbtagsVar     .find(varNames[ivar].Data())!=nbtagsVar     .end())nbtags      = nbtagsVar     [varNames[ivar].Data()];
            auto& mindphijmet  = mindphijmetVar[""];    if(mindphijmetVar.find(varNames[ivar].Data())!=mindphijmetVar.end())mindphijmet = mindphijmetVar[varNames[ivar].Data()];
@@ -1490,36 +1496,36 @@ int main(int argc, char* argv[])
                if(L>0 && !(photonTrigger && gammaWgtHandler) )continue; //run it only for photon reweighting
                weight = weightBefLoop;
                std::vector<TString> chTags;
-               TString evCat;       
+               TString evCat;
                int dilId(1);
                LorentzVector boson(0,0,0,0);
-               if(selLeptons.size()==2  && !gammaWgtHandler){  //this is not run if photon reweighting is activated to avoid mixing           
+               if(selLeptons.size()==2  && !gammaWgtHandler){  //this is not run if photon reweighting is activated to avoid mixing
                    for(size_t ilep=0; ilep<2; ilep++){
                        dilId *= selLeptons[ilep].pdgId();
                        int id(abs(selLeptons[ilep].pdgId()));
 		       if(is2016MC) {
-			   
-                           if(id==11)weight *= lepEff.getTrackingEfficiency( selLeptons[ilep].el.superCluster()->eta(), id).first; //Tracking eff 
+
+                           if(id==11)weight *= lepEff.getTrackingEfficiency( selLeptons[ilep].el.superCluster()->eta(), id).first; //Tracking eff
                            else if(id==13)weight *= lepEff.getTrackingEfficiency( selLeptons[ilep].eta(), id).first; //Tracking eff
-                           weight *= isMC ? lepEff.getLeptonEfficiency( selLeptons[ilep].pt(), selLeptons[ilep].eta(), id,  id ==11 ? "tight"    : "tight"   ,patUtils::CutVersion::ICHEP16Cut ).first : 1.0; //ID 
+                           weight *= isMC ? lepEff.getLeptonEfficiency( selLeptons[ilep].pt(), selLeptons[ilep].eta(), id,  id ==11 ? "tight"    : "tight"   ,patUtils::CutVersion::ICHEP16Cut ).first : 1.0; //ID
                            weight *= isMC ? lepEff.getLeptonEfficiency( selLeptons[ilep].pt(), selLeptons[ilep].eta(), id,  id ==11 ? "tightiso" : "tightiso",patUtils::CutVersion::ICHEP16Cut ).first : 1.0; //ISO w.r.t ID
 		       } else if(isMC && !is2016MC){
-                           weight *= isMC ? lepEff.getLeptonEfficiency( selLeptons[ilep].pt(), selLeptons[ilep].eta(), id,  id ==11 ? "tight"    : "tight"   ,patUtils::CutVersion::Spring15Cut25ns).first : 1.0; //ID 
+                           weight *= isMC ? lepEff.getLeptonEfficiency( selLeptons[ilep].pt(), selLeptons[ilep].eta(), id,  id ==11 ? "tight"    : "tight"   ,patUtils::CutVersion::Spring15Cut25ns).first : 1.0; //ID
                            weight *= isMC ? lepEff.getLeptonEfficiency( selLeptons[ilep].pt(), selLeptons[ilep].eta(), id,  id ==11 ? "tightiso" : "tightiso",patUtils::CutVersion::Spring15Cut25ns).first : 1.0; //ISO w.r.t ID
 
 		       }
 
                        boson += selLeptons[ilep].p4();
-                   }        
+                   }
                    //check the channel
                    if( abs(dilId)==121){  chTags.push_back("ee");   chTags.push_back("ll"); }
                    if( abs(dilId)==169){  chTags.push_back("mumu"); chTags.push_back("ll"); }
-                   if( abs(dilId)==143){  chTags.push_back("emu");  }           
+                   if( abs(dilId)==143){  chTags.push_back("emu");  }
 		   if (isOldMC) {
-		     if(isMC && abs(dilId)==169)weight *= lepEff.getTriggerEfficiencySF(selLeptons[0].pt(), selLeptons[0].eta(), selLeptons[1].pt(), selLeptons[1].eta(), dilId,is2016MC).first;  
+		     if(isMC && abs(dilId)==169)weight *= lepEff.getTriggerEfficiencySF(selLeptons[0].pt(), selLeptons[0].eta(), selLeptons[1].pt(), selLeptons[1].eta(), dilId,is2016MC).first;
 		     if(isMC && abs(dilId)==121)weight *= lepEff.getTriggerEfficiencySF(selLeptons[0].pt(), selLeptons[0].el.superCluster()->eta(), selLeptons[1].pt(), selLeptons[1].el.superCluster()->eta(), dilId,is2016MC).first;  //commented for ee as inefficiencies should be covered by the singleMu/El triggers
                    }
-		   evCat=eventCategoryInst.GetCategory(selJets,boson);            
+		   evCat=eventCategoryInst.GetCategory(selJets,boson);
                }else if(selPhotons.size()==1 && photonTrigger){
                    dilId=22;
                    if(L==0)                         {chTags.push_back("gamma");
@@ -1528,24 +1534,24 @@ int main(int argc, char* argv[])
                    }else{ continue;
                    }
                    boson = selPhotons[0].p4();
-                   evCat=eventCategoryInst.GetCategory(selJets,boson);            
+                   evCat=eventCategoryInst.GetCategory(selJets,boson);
                    if(L>0 && gammaWgtHandler)boson = gammaWgtHandler->getMassiveP4(boson, string(L==1?"ee":"mumu")+evCat);
                    std::vector<Float_t> photonVars;
-                   photonVars.push_back(boson.pt());           
+                   photonVars.push_back(boson.pt());
                    float photonWeightMain=1.0;
-		   float photonPuWeight=1.0;  
+		   float photonPuWeight=1.0;
                    if(L>0 && gammaWgtHandler) {
 		     photonWeightMain=gammaWgtHandler->getWeightFor(photonVars,string(L==1?"ee":"mumu")+evCat);
-		     
-		     if (doPUCorrections) { 
+
+		     if (doPUCorrections) {
 		       TString puWeightsFileUrl(puWeightsFilePath[0].c_str());
-		       gSystem->ExpandPathName(puWeightsFileUrl); 
-		       puWeightsFile=TFile::Open(puWeightsFileUrl); 
- 
+		       gSystem->ExpandPathName(puWeightsFileUrl);
+		       puWeightsFile=TFile::Open(puWeightsFileUrl);
+
 		       if (puWeightsFile) {
-			 TH2D* h_pu_zpt_weight = (TH2D*)puWeightsFile->Get(L==1?"h_rho_zpt_weight_e":"h_rho_zpt_weight_m");  
-			 photonPuWeight=h_pu_zpt_weight->GetBinContent(h_pu_zpt_weight->FindBin(boson.pt(), vtx.size())); 
-			 puWeightsFile->Close(); 
+			 TH2D* h_pu_zpt_weight = (TH2D*)puWeightsFile->Get(L==1?"h_rho_zpt_weight_e":"h_rho_zpt_weight_m");
+			 photonPuWeight=h_pu_zpt_weight->GetBinContent(h_pu_zpt_weight->FindBin(boson.pt(), vtx.size()));
+			 puWeightsFile->Close();
 		       }
 		     }
 		   }
@@ -1570,7 +1576,7 @@ int main(int argc, char* argv[])
                bool passMass(fabs(boson.mass()-91)<15);
                bool passQt(boson.pt()>55);
                bool passThirdLeptonVeto( selLeptons.size()==2 && extraLeptons.size()==0 );
-               bool passBtags(nbtags==0); 
+               bool passBtags(nbtags==0);
                bool passMinDphijmet( njets==0 || mindphijmet>0.5);
 
 
@@ -1585,7 +1591,7 @@ int main(int argc, char* argv[])
               }
 
               double mt=0;
-              if(passQt && passThirdLeptonVeto && passMinDphijmet && (boson.mass()>40 && boson.mass()<200)) mt=higgs::utils::transverseMass(boson,imet,true);             
+              if(passQt && passThirdLeptonVeto && passMinDphijmet && (boson.mass()>40 && boson.mass()<200)) mt=higgs::utils::transverseMass(boson,imet,true);
 
 
                if(ivar==0){  //fill control plots only for the nominal systematic
@@ -1595,20 +1601,20 @@ int main(int argc, char* argv[])
                   mon.fillHisto("npho55", tags, nPho55, weight);
                   mon.fillHisto("npho100", tags, nPho100, weight);
                   if(photonTrigger && selPhotons.size()>0)mon.fillHisto("photonpt", tags[tags.size()-1]+photonTriggerTreshName,   selPhotons[0].pt(), weight);
-                 
+
 
                   // Photon trigger efficiencies
                   // Must be run without the photonTrigger requirement on top of of the Analysis.
                   if (photonTriggerStudy && selPhotons.size() ){
                     TString tag="trigger";
                     pat::Photon iphoton = selPhotons[0];
-               
+
                     mon.fillHisto("phopt", tag, iphoton.pt(),weight);
                     mon.fillHisto("phoeta", tag, iphoton.eta(), weight);
                     trigUtils::photonControlSample(ev, iphoton, mon, tag);
                     trigUtils::photonControlEff(ev, iphoton, mon, tag);
 
-                    for(size_t itag=0; itag<tags.size(); itag++){		
+                    for(size_t itag=0; itag<tags.size(); itag++){
                       //update the weight
                       TString icat=tags[itag];
                       mon.fillHisto("phopt", icat, iphoton.pt(),weight);
@@ -1631,14 +1637,14 @@ int main(int argc, char* argv[])
                   if(chTags.size()==0) continue;
                   mon.fillHisto("eventflow",  tags,1,weight);
                   if(dilId!=22){
-                    mon.fillHisto("leadpt",      tags,selLeptons[0].pt(),weight); 
-                    mon.fillHisto("trailerpt",   tags,selLeptons[1].pt(),weight); 
-                    mon.fillHisto("leadeta",     tags,fabs(selLeptons[0].eta()),weight); 
-                    mon.fillHisto("trailereta",  tags,fabs(selLeptons[1].eta()),weight); 
+                    mon.fillHisto("leadpt",      tags,selLeptons[0].pt(),weight);
+                    mon.fillHisto("trailerpt",   tags,selLeptons[1].pt(),weight);
+                    mon.fillHisto("leadeta",     tags,fabs(selLeptons[0].eta()),weight);
+                    mon.fillHisto("trailereta",  tags,fabs(selLeptons[1].eta()),weight);
                   }
-           
-                  mon.fillHisto("zmass", tags,boson.mass(),weight); 
-                  mon.fillHisto("zy",    tags,fabs(boson.Rapidity()),weight); 
+
+                  mon.fillHisto("zmass", tags,boson.mass(),weight);
+                  mon.fillHisto("zy",    tags,fabs(boson.Rapidity()),weight);
 
                   if(passMass){
                     mon.fillHisto("eventflow",tags, 2,weight);
@@ -1648,8 +1654,8 @@ int main(int argc, char* argv[])
 
 
                     //these two are used to reweight photon -> Z, the 3rd is a control
-                    mon.fillHisto("qt",       tags, boson.pt(),weight,true); 
-                    mon.fillHisto("qtraw",    tags, boson.pt(),weight/triggerPrescale,true); 
+                    mon.fillHisto("qt",       tags, boson.pt(),weight,true);
+                    mon.fillHisto("qtraw",    tags, boson.pt(),weight/triggerPrescale,true);
 
                     if(passQt){
                       mon.fillHisto("eventflow",tags,3,weight);
@@ -1664,11 +1670,11 @@ int main(int argc, char* argv[])
                         mon.fillHisto("thirdleptonmt",tags,mt3rd,weight);
                       }
                       if(passThirdLeptonVeto){
-                        
+
                         mon.fillHisto("eventflow",tags,4,weight);
 
 			if (selJets.size()>0) {
-			  mon.fillHisto( "leadjet_pt",tags,selJets[0].pt(),weight);       
+			  mon.fillHisto( "leadjet_pt",tags,selJets[0].pt(),weight);
 			  mon.fillHisto( "leadjet_eta",tags,fabs(selJets[0].eta()),weight);
 			  mon.fillHisto( "leadjet_phi",tags,selJets[0].phi(),weight);
 			}
@@ -1686,7 +1692,7 @@ int main(int argc, char* argv[])
                           mon.fillHisto( "csv"+jetFlav,tags,csv,weight);
                         }
                         mon.fillHisto( "nbtags",tags,nbtags,weight);
-                        
+
                         if(passBtags){
                           mon.fillHisto("eventflow",tags,5,weight);
 
@@ -1696,22 +1702,22 @@ int main(int argc, char* argv[])
                           if(imet.pt()>80)mon.fillHisto( "mindphijmetNM1",tags,mindphijmet,weight);
                           if(passMinDphijmet){
                             mon.fillHisto("eventflow",tags,6,weight);
-                           
+
                             //this one is used to sample the boson mass: cuts may shape Z lineshape
-                            mon.fillHisto("qmass",       tags, boson.mass(),weight); 
+                            mon.fillHisto("qmass",       tags, boson.mass(),weight);
                             mon.fillHisto( "njets",tags,njets,weight);
-       
+
                             double b_dphi=fabs(deltaPhi(boson.phi(),imet.phi()));
                             mon.fillHisto( "metphi",tags,imet.phi(),weight);
                             mon.fillHisto( "metphiUnCor",tags,met.corP4(pat::MET::METCorrectionLevel::Type1).phi(),weight);
-                            mon.fillHisto( "bosonnvtx",tags,vtx.size(),weight);                                                               
-			    mon.fillHisto( "bosonrho",tags,rho,weight); 
+                            mon.fillHisto( "bosonnvtx",tags,vtx.size(),weight);
+			    mon.fillHisto( "bosonrho",tags,rho,weight);
 
-                            mon.fillHisto( "bosoneta",tags,boson.eta(),weight);                                                                                
-                            mon.fillHisto( "bosonphi",tags,boson.phi(),weight);                                                               
+                            mon.fillHisto( "bosoneta",tags,boson.eta(),weight);
+                            mon.fillHisto( "bosonphi",tags,boson.phi(),weight);
                             mon.fillHisto( "bosonphiHG",tags,boson.phi(),weight);
                             mon.fillHisto( "dphi_boson_met",tags,b_dphi,weight);
-       
+
                             mon.fillHisto( "met",tags,imet.pt(),weight,true);
                             mon.fillHisto( "metpuppi",tags,puppimet.pt(),weight,true);
                             mon.fillHisto( "balance",tags,imet.pt()/boson.pt(),weight);
@@ -1720,7 +1726,7 @@ int main(int argc, char* argv[])
                             TVector2 boson2(boson.px(), boson.py());
                             double axialMet(boson2*met2); axialMet/=-boson.pt();
                             mon.fillHisto( "axialmet",tags,axialMet,weight);
-       
+
                             mon.fillHisto( "mt",tags,mt,weight,true);
 
                             if(imet.pt()>optim_Cuts1_met[0]) {
@@ -1738,20 +1744,20 @@ int main(int argc, char* argv[])
                             if(imet.pt()>125){
                               mon.fillHisto("eventflow",tags,8,weight);
 
-                              mon.fillHisto( "metfinal",tags,imet.pt(),weight,true);                      
+                              mon.fillHisto( "metfinal",tags,imet.pt(),weight,true);
                               mon.fillHisto( "mtfinal",tags,mt,weight,true);
                               mon.fillHisto( "mindphijmetfinal",tags,mindphijmet,weight);
                               mon.fillHisto( "njetsfinal",tags,njets,weight);
                               if(!isMC){
                                  char buffer[1024];
-                                 sprintf(buffer, "\ncat=%s %9i:%6i:%9lli @ %50s\n",  tags[tags.size()-1].Data(), ev.eventAuxiliary().run(), ev.eventAuxiliary().luminosityBlock(), ev.eventAuxiliary().event(), urls[f].c_str() );  debugText+=buffer; 
-                                 sprintf(buffer, " - nLep=%2i nSoftLept=%2i nPhotons=%2i  nJets=%2i\n", int(selLeptons.size()), int(extraLeptons.size()), int(selPhotons.size()), int(selJets.size())  ); debugText+=buffer;                               
+                                 sprintf(buffer, "\ncat=%s %9i:%6i:%9lli @ %50s\n",  tags[tags.size()-1].Data(), ev.eventAuxiliary().run(), ev.eventAuxiliary().luminosityBlock(), ev.eventAuxiliary().event(), urls[f].c_str() );  debugText+=buffer;
+                                 sprintf(buffer, " - nLep=%2i nSoftLept=%2i nPhotons=%2i  nJets=%2i\n", int(selLeptons.size()), int(extraLeptons.size()), int(selPhotons.size()), int(selJets.size())  ); debugText+=buffer;
                                  sprintf(buffer, " - MET=%8.2f mT=%8.2f nvtx=%3i\n", imet.pt(), mt, int(vtx.size()) ); debugText+=buffer;
                                  sprintf(buffer, " - MET type1XY=%8.2f type1=%8.2f uncorrected=%8.2f\n", met.corP4(pat::MET::METCorrectionLevel::Type1XY).pt(), met.corP4(pat::MET::METCorrectionLevel::Type1).pt(), met.corP4(pat::MET::METCorrectionLevel::Raw).pt() ); debugText+=buffer;
-                                 sprintf(buffer, " - LeptonScale changes on MET mu=%8.2f  el=%8.2f\n", muDiff.pt(), elDiff.pt() ); debugText+=buffer;                        
+                                 sprintf(buffer, " - LeptonScale changes on MET mu=%8.2f  el=%8.2f\n", muDiff.pt(), elDiff.pt() ); debugText+=buffer;
                                  sprintf(buffer, " - Z pT=%6.2f eta=%+6.2f phi=%+6.2f\n", boson.pt(), boson.eta(), boson.phi() ); debugText+=buffer;
                                  if(selLeptons.size()>0)sprintf(buffer, " - lep0 Id=%+3i pT=%6.2f, eta=%+6.2f phi=%+6.2f\n", selLeptons[0].pdgId(), selLeptons[0].pt(), selLeptons[0].eta(), selLeptons[0].phi()  ); debugText+=buffer;
-                                 if(selLeptons.size()>1)sprintf(buffer, " - lep1 Id=%+3i pT=%6.2f, eta=%+6.2f phi=%+6.2f\n", selLeptons[1].pdgId(), selLeptons[1].pt(), selLeptons[1].eta(), selLeptons[1].phi()  ); debugText+=buffer;                                
+                                 if(selLeptons.size()>1)sprintf(buffer, " - lep1 Id=%+3i pT=%6.2f, eta=%+6.2f phi=%+6.2f\n", selLeptons[1].pdgId(), selLeptons[1].pt(), selLeptons[1].eta(), selLeptons[1].phi()  ); debugText+=buffer;
                                }
                             }
 
@@ -1772,7 +1778,7 @@ int main(int argc, char* argv[])
                                 float fwdEta( fabs(eta1)>fabs(eta2) ? eta1 : eta2);
                                 float cenEta( fabs(eta1)>fabs(eta2) ? eta2 : eta1);
                                 mon.fillHisto("vbfjeteta", tags,fabs(fwdEta),  weight);
-                                mon.fillHisto("vbfjeteta", tags,fabs(cenEta),  weight);                          
+                                mon.fillHisto("vbfjeteta", tags,fabs(cenEta),  weight);
                                 mon.fillHisto("fwdjeteta",tags,fabs(fwdEta),  weight);
                                 mon.fillHisto("cenjeteta",tags,fabs(cenEta),  weight);
                                 mon.fillHisto("vbfdetajj",tags,deta,        weight);
@@ -1793,14 +1799,14 @@ int main(int argc, char* argv[])
 
                                 if(imet.pt()>125){
 
-                                    mon.fillHisto("vbfdetajjfinal",tags,deta,        weight);                          
+                                    mon.fillHisto("vbfdetajjfinal",tags,deta,        weight);
                                     if(deta>4.0){mon.fillHisto("vbfdphijjfinal",tags,dphi,        weight);}
 
                                     if(!isMC){
-                                       char buffer[1024];                           
+                                       char buffer[1024];
                                        sprintf(buffer, " - VBF mjj=%8.2f  dEta=%+6.2f dPhi=%+6.2f\n", dijet.mass(), deta, dphi   ); debugText+=buffer;
-                                       sprintf(buffer, " - VBF jet1 pT=%6.2f eta=%+6.2f phi=%+6.2f\n", selJets[0].pt(), selJets[0].eta(), selJets[0].phi()   ); debugText+=buffer;                                
-                                       sprintf(buffer, " - VBF jet2 pT=%6.2f eta=%+6.2f phi=%+6.2f\n", selJets[1].pt(), selJets[1].eta(), selJets[1].phi()   ); debugText+=buffer;                                                            
+                                       sprintf(buffer, " - VBF jet1 pT=%6.2f eta=%+6.2f phi=%+6.2f\n", selJets[0].pt(), selJets[0].eta(), selJets[0].phi()   ); debugText+=buffer;
+                                       sprintf(buffer, " - VBF jet2 pT=%6.2f eta=%+6.2f phi=%+6.2f\n", selJets[1].pt(), selJets[1].eta(), selJets[1].phi()   ); debugText+=buffer;
                                     }
                                 }
 
@@ -1809,40 +1815,40 @@ int main(int argc, char* argv[])
                           }
                         }
                       }
-                    }        
+                    }
                   }
 
-                  bool isZsideBand    ( (boson.mass()>40  && boson.mass()<70) || (boson.mass()>110 && boson.mass()<200) );              
+                  bool isZsideBand    ( (boson.mass()>40  && boson.mass()<70) || (boson.mass()>110 && boson.mass()<200) );
                   if(passQt && passThirdLeptonVeto && passMinDphijmet && (boson.mass()>40 && boson.mass()<200)){
-                     if(passBtags){                                      
-                        if(imet.pt()>50 )mon.fillHisto("zmass_bveto50" , tags,boson.mass(),weight); 
-                        if(imet.pt()>80 )mon.fillHisto("zmass_bveto80" , tags,boson.mass(),weight); 
-                        if(imet.pt()>125)mon.fillHisto("zmass_bveto125", tags,boson.mass(),weight); 
+                     if(passBtags){
+                        if(imet.pt()>50 )mon.fillHisto("zmass_bveto50" , tags,boson.mass(),weight);
+                        if(imet.pt()>80 )mon.fillHisto("zmass_bveto80" , tags,boson.mass(),weight);
+                        if(imet.pt()>125)mon.fillHisto("zmass_bveto125", tags,boson.mass(),weight);
                         if(passMass){
                             mon.fillHisto( "met_Inbveto",tags,imet.pt(),weight);
-                           if(imet.pt()>50 )mon.fillHisto("mt_Inbveto50" , tags,mt,weight); 
-                           if(imet.pt()>80 )mon.fillHisto("mt_Inbveto80" , tags,mt,weight); 
-                           if(imet.pt()>125)mon.fillHisto("mt_Inbveto125", tags,mt,weight); 
+                           if(imet.pt()>50 )mon.fillHisto("mt_Inbveto50" , tags,mt,weight);
+                           if(imet.pt()>80 )mon.fillHisto("mt_Inbveto80" , tags,mt,weight);
+                           if(imet.pt()>125)mon.fillHisto("mt_Inbveto125", tags,mt,weight);
                         }else if(isZsideBand){
                             mon.fillHisto( "met_Outbveto",tags,imet.pt(),weight);
-                           if(imet.pt()>50 )mon.fillHisto("mt_Outbveto50" , tags,mt,weight); 
-                           if(imet.pt()>80 )mon.fillHisto("mt_Outbveto80" , tags,mt,weight); 
-                           if(imet.pt()>125)mon.fillHisto("mt_Outbveto125", tags,mt,weight); 
+                           if(imet.pt()>50 )mon.fillHisto("mt_Outbveto50" , tags,mt,weight);
+                           if(imet.pt()>80 )mon.fillHisto("mt_Outbveto80" , tags,mt,weight);
+                           if(imet.pt()>125)mon.fillHisto("mt_Outbveto125", tags,mt,weight);
                         }
                      }else{
-                        if(imet.pt()>50 )mon.fillHisto("zmass_btag50" , tags,boson.mass(),weight); 
-                        if(imet.pt()>80 )mon.fillHisto("zmass_btag80" , tags,boson.mass(),weight); 
-                        if(imet.pt()>125)mon.fillHisto("zmass_btag125", tags,boson.mass(),weight); 
+                        if(imet.pt()>50 )mon.fillHisto("zmass_btag50" , tags,boson.mass(),weight);
+                        if(imet.pt()>80 )mon.fillHisto("zmass_btag80" , tags,boson.mass(),weight);
+                        if(imet.pt()>125)mon.fillHisto("zmass_btag125", tags,boson.mass(),weight);
                         if(passMass){
                             mon.fillHisto( "met_Inbtag",tags,imet.pt(),weight);
-                           if(imet.pt()>50 )mon.fillHisto("mt_Inbtag50" , tags,mt,weight); 
-                           if(imet.pt()>80 )mon.fillHisto("mt_Inbtag80" , tags,mt,weight); 
-                           if(imet.pt()>125)mon.fillHisto("mt_Inbtag125", tags,mt,weight); 
+                           if(imet.pt()>50 )mon.fillHisto("mt_Inbtag50" , tags,mt,weight);
+                           if(imet.pt()>80 )mon.fillHisto("mt_Inbtag80" , tags,mt,weight);
+                           if(imet.pt()>125)mon.fillHisto("mt_Inbtag125", tags,mt,weight);
                         }else if(isZsideBand){
                             mon.fillHisto( "met_Outbtag",tags,imet.pt(),weight);
-                           if(imet.pt()>50 )mon.fillHisto("mt_Outbtag50" , tags,mt,weight); 
-                           if(imet.pt()>80 )mon.fillHisto("mt_Outbtag80" , tags,mt,weight); 
-                           if(imet.pt()>125)mon.fillHisto("mt_Outbtag125", tags,mt,weight); 
+                           if(imet.pt()>50 )mon.fillHisto("mt_Outbtag50" , tags,mt,weight);
+                           if(imet.pt()>80 )mon.fillHisto("mt_Outbtag80" , tags,mt,weight);
+                           if(imet.pt()>125)mon.fillHisto("mt_Outbtag125", tags,mt,weight);
                         }
                      }
                   }
@@ -1850,18 +1856,18 @@ int main(int argc, char* argv[])
                }
 
 
-               //if(ivar==0)printf("%9i:%9lli SYST:%30s  Met=%8.3f mT=%8.3f  Weight=%6.2E %i %i %i %i %i\n",  ev.eventAuxiliary().run(), ev.eventAuxiliary().event(), "NOSYST", imet.pt(), higgs::utils::transverseMass(boson,imet,true), weight, passBtags?1:0, passMass?1:0, passQt?1:0, passThirdLeptonVeto?1:0, passMinDphijmet?1:0 ); 
+               //if(ivar==0)printf("%9i:%9lli SYST:%30s  Met=%8.3f mT=%8.3f  Weight=%6.2E %i %i %i %i %i\n",  ev.eventAuxiliary().run(), ev.eventAuxiliary().event(), "NOSYST", imet.pt(), higgs::utils::transverseMass(boson,imet,true), weight, passBtags?1:0, passMass?1:0, passQt?1:0, passThirdLeptonVeto?1:0, passMinDphijmet?1:0 );
 
                if(passBtags && passMass && passQt && passThirdLeptonVeto && passMinDphijmet){
 
                   mon.fillHisto(TString("mtSyst")+varNames[ivar],tags, mt,weight);
-                  mon.fillHisto(TString("metSyst")+varNames[ivar],tags, imet.pt(),weight);                    
+                  mon.fillHisto(TString("metSyst")+varNames[ivar],tags, imet.pt(),weight);
 
 
 
 
                   //scan the MET cut and fill the shapes
-                  for(unsigned int index=0;index<optim_Cuts1_met.size();index++){             
+                  for(unsigned int index=0;index<optim_Cuts1_met.size();index++){
                      if(imet.pt()>optim_Cuts1_met[index]){
                        for(unsigned int nri=0;nri<NRparams.size();nri++){
                           //Higgs line shape
@@ -1888,17 +1894,17 @@ int main(int argc, char* argv[])
                           }
 
                           mon.fillHisto(TString("mt_shapes")+NRsuffix[nri]+varNames[ivar],tags,index, mt,shapeWeight);
-                          mon.fillHisto(TString("met_shapes")+NRsuffix[nri]+varNames[ivar],tags,index, imet.pt(),shapeWeight);                    
+                          mon.fillHisto(TString("met_shapes")+NRsuffix[nri]+varNames[ivar],tags,index, imet.pt(),shapeWeight);
                        }
                     }
                  }
               }
 
                if(passQt && passThirdLeptonVeto && passMinDphijmet && (boson.mass()>40 && boson.mass()<200)){
-                  bool isZ_SB ( (boson.mass()>40  && boson.mass()<70) || (boson.mass()>110 && boson.mass()<200) );              
-                  bool isZ_upSB ( (boson.mass()>110 && boson.mass()<200) );              
+                  bool isZ_SB ( (boson.mass()>40  && boson.mass()<70) || (boson.mass()>110 && boson.mass()<200) );
+                  bool isZ_upSB ( (boson.mass()>110 && boson.mass()<200) );
                   //scan the MET cut and fill the shapes
-                  for(unsigned int index=0;index<optim_Cuts1_met.size();index++){             
+                  for(unsigned int index=0;index<optim_Cuts1_met.size();index++){
                      if(imet.pt()>optim_Cuts1_met[index]){
                        for(unsigned int nri=0;nri<NRparams.size();nri++){
                           //Higgs line shape
@@ -1908,8 +1914,8 @@ int main(int argc, char* argv[])
                                 shapeWeight = (weight*lMelaShapeWeights[nri][MelaMode])/lMelaShapeWeights[0][MelaMode];
                           } else if( !isMELA ){
                                 shapeWeight =  weight;
-                          }                 
-                
+                          }
+
                           if( !isMELA ){
                              double weightToOtherNRI = ( (lShapeWeights[nri][0] * lShapeWeights[nri][1]) / (lShapeWeights[0][0] * lShapeWeights[0][1]) );  //remove weights form nri=0 as those are already in the nominal weight and apply the one for NRI!=0;
                              if(!std::isnan((double)weightToOtherNRI))shapeWeight *= weightToOtherNRI;
@@ -1923,7 +1929,7 @@ int main(int argc, char* argv[])
                              if( varNames[ivar]=="_signal_normup"     ) shapeWeight*=lMelaShapeWeights[nri][MelaMode];
                              if( varNames[ivar]=="_signal_lshapeup"   ) shapeWeight*=lMelaShapeWeights[nri][MelaMode];
                           }
-               
+
                           if(passBtags && passMass)mon.fillHisto(TString("mt_shapes_NRBctrl")+NRsuffix[nri]+varNames[ivar],tags,index, 0.5,shapeWeight);
                           if(passBtags && isZ_SB)mon.fillHisto(TString("mt_shapes_NRBctrl")+NRsuffix[nri]+varNames[ivar],tags,index, 1.5,shapeWeight);
                           if(passBtags && isZ_upSB)mon.fillHisto(TString("mt_shapes_NRBctrl")+NRsuffix[nri]+varNames[ivar],tags,index, 2.5,shapeWeight);
@@ -1938,30 +1944,30 @@ int main(int argc, char* argv[])
             }
          }
      }
-     printf("\n"); 
+     printf("\n");
      delete file;
-  } 
+  }
 
   //##############################################
   //########     SAVING HISTO TO FILE     ########
   //##############################################
   //
- 
+
   //scale all events by 1/N to avoid the initial loop to stupidly count the events
   //mon.Scale(1.0/totalNumEvent);
 
   TString terminationCmd = "";
   //save control plots to file
   printf("Results save in local directory and moved to %s\n", outUrl.Data());
-  
+
   //save all to the file
   terminationCmd += TString("mv out.root ") + outUrl + ";";
   TFile *ofile=TFile::Open("out.root", "recreate");
   mon.Write();
   ofile->Close();
 
-  if(!isMC && debugText!=""){ 
-     TString outTxtUrl= outUrl + ".txt";    
+  if(!isMC && debugText!=""){
+     TString outTxtUrl= outUrl + ".txt";
      terminationCmd += TString("mv out.txt ") + outTxtUrl + ";";
      FILE* outTxtFile = fopen("out.txt", "w");
      fprintf(outTxtFile, "%s", debugText.c_str());
@@ -1978,4 +1984,4 @@ int main(int argc, char* argv[])
 
   system(terminationCmd.Data());
 
-}  
+}

--- a/interface/PatUtils.h
+++ b/interface/PatUtils.h
@@ -78,7 +78,7 @@ namespace patUtils
    namespace llvvMuonId { enum MuonId  {Loose, Soft, Tight, tkHighPT, TightAndTlkHighPt, StdLoose, StdSoft, StdMedium, StdTight}; }
    namespace llvvPhotonId { enum PhotonId  {Loose, Medium, Tight}; }
    namespace llvvElecIso{ enum ElecIso {Veto, Loose, Medium, Tight}; }
-   namespace llvvMuonIso{ enum MuonIso {Loose,Tight, H4lWP}; }
+   namespace llvvMuonIso{ enum MuonIso {Loose,Tight, H4lWP, TightBoosted, TightAndTkRelatBoosted}; }
    namespace CutVersion { enum CutSet {Spring15Cut25ns, ICHEP16Cut, Moriond17Cut}; }
 
    bool passId (VersionedPatElectronSelector id, edm::EventBase const & event, pat::Electron el);
@@ -89,8 +89,9 @@ namespace patUtils
    bool passIso (VersionedPatElectronSelector id, pat::Electron& el);
    bool passIso(pat::Electron& el,  int IsoLevel, int cutVersion, double rho=0.0 ); // Old PHYS15 Iso
    bool passIso(pat::Muon&     mu,  int IsoLevel, int cutVersion);
-   bool passPhotonTrigger(fwlite::Event &ev, float &triggerThreshold, float &triggerPrescale, float& triggerThresholdHigh); 
-   bool passVBFPhotonTrigger(fwlite::Event &ev, float &triggerThreshold, float &triggerPrescale, float& triggerThresholdHigh); 
+   bool passIso(pat::Muon& mu, int IsoLevel, int cutVersion, std::vector<pat::PackedCandidate> thePats, pat::MuonCollection muons, reco::Vertex& vertex );
+   bool passPhotonTrigger(fwlite::Event &ev, float &triggerThreshold, float &triggerPrescale, float& triggerThresholdHigh);
+   bool passVBFPhotonTrigger(fwlite::Event &ev, float &triggerThreshold, float &triggerPrescale, float& triggerThresholdHigh);
    bool passPFJetID(std::string label, pat::Jet jet);
    bool passPUJetID(pat::Jet j);
 
@@ -100,13 +101,15 @@ namespace patUtils
    double alphaVariation(const fwlite::Event& ev);
    double pdfVariation(const fwlite::Event& ev);
 
-   double getHTScaleFactor(TString dtag, double lheHt);                                                                                               
+   double getHTScaleFactor(TString dtag, double lheHt);
   bool outInOnly(const reco::Muon &mu)  ;
-  bool preselection(const reco::Muon &mu,bool selectClones_)  ; 
-  bool tighterId(const reco::Muon &mu)  ; 
+  bool preselection(const reco::Muon &mu,bool selectClones_)  ;
+  bool tighterId(const reco::Muon &mu)  ;
   bool tightGlobal(const reco::Muon &mu)  ;
   bool safeId(const reco::Muon &mu)  ;
   bool partnerId(const reco::Muon &mu)  ;
+  float computePFphotonIsolation(std::vector<pat::PackedCandidate>, float , float , const pat::Muon &, pat::MuonCollection , reco::Vertex& vertex);
+  float makeTkIsoCloseBySafe( float coneSize, float initialValue, const pat::Muon &theMuon, pat::MuonCollection muons);
 
 
 
@@ -132,12 +135,12 @@ namespace patUtils
      void Clear(){map.clear();}
      void FillBadEvents(std::string path);
 
-     //     New Met Filters for 2016 Run II:    
+     //     New Met Filters for 2016 Run II:
      bool passBadPFMuonFilter(const fwlite::Event& ev);
-     bool passBadChargedCandidateFilter(const fwlite::Event& ev);   
-     
+     bool passBadChargedCandidateFilter(const fwlite::Event& ev);
+
      int  passMetFilterInt(const fwlite::Event& ev);
-     int  passMetFilterInt(const fwlite::Event& ev, bool is2016); 
+     int  passMetFilterInt(const fwlite::Event& ev, bool is2016);
      bool passMetFilter(const fwlite::Event& ev);
      bool BadGlobalMuonTaggerFilter(const fwlite::Event& ev,std::unique_ptr<edm::PtrVector<reco::Muon>> &out, bool selectClones=false);
      bool BadGlobalMuonTaggerFilter(const fwlite::Event& ev,std::unique_ptr<std::vector<reco::Muon*>> &out, bool selectClones=false);

--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -5,15 +5,84 @@
 namespace patUtils
 {
 
+  float makeTkIsoCloseBySafe( float coneSize, float initialValue, const pat::Muon &theMuon, pat::MuonCollection muons){
+    float returnValue = initialValue;
+    for (unsigned int i=0 ; i<muons.size() ; i++){
+       pat::Muon &otherMu = muons.at(i);
+       float theDeltaR2 = deltaR2(theMuon, otherMu);
+       if (theDeltaR2==0) continue; //it is the same muon
+       bool tkHighPt = otherMu.isTrackerMuon() && otherMu.track().isNonnull() && otherMu.numberOfMatchedStations() > 1 && (otherMu.muonBestTrack()->ptError()/otherMu.muonBestTrack()->pt()) < 0.3 && otherMu.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 && otherMu.innerTrack()->hitPattern().trackerLayersWithMeasurement()>5;
+       if (!(tkHighPt)) continue; //remove the other muon only if passes the tkHighpt id
+       if (theDeltaR2<(coneSize*coneSize)) returnValue = returnValue - otherMu.innerTrack()->pt();
+    }
+    return returnValue;
+  }
+  float computePFphotonIsolation(std::vector<pat::PackedCandidate> thePFparticles, float coneSize, float threshold, const pat::Muon &theMuon, pat::MuonCollection muons, reco::Vertex& vertex){
+    std::vector<unsigned int> listOfFSRphoton;
+    for (unsigned int j = 0; j < muons.size(); ++j) {
+      std::vector<unsigned int> listOfFSRphotonForThisMuon;
+      const reco::Muon &otherMu = muons.at(j);
+      if (!(muon::isLooseMuon(otherMu))) continue;
+      float dxy = otherMu.innerTrack()->dxy(vertex.position());
+      float dz = otherMu.innerTrack()->dz(vertex.position());
+      if (!(fabs(dxy)<0.5)) continue;
+      if (!(fabs(dz)<1)) continue;
+      for (unsigned int itePat=0 ; itePat<thePFparticles.size(); itePat++){
+        pat::PackedCandidate aPat = thePFparticles.at(itePat);
+        if (!(fabs(aPat.pdgId())==22)) continue;
+        float deltaR = sqrt(deltaR2(aPat,otherMu));
+        float estimator = deltaR/(aPat.pt()*aPat.pt());
+        if ((estimator<0.012)&&(deltaR<0.5)) listOfFSRphotonForThisMuon.push_back(itePat);
+      }
+      if (listOfFSRphotonForThisMuon.size()>1){
+        int minIte=-1;
+        float minEstimator=100;
+        for (unsigned int m=0;m<listOfFSRphotonForThisMuon.size(); m++){
+          pat::PackedCandidate aPat = thePFparticles.at(listOfFSRphotonForThisMuon.at(m));
+          float deltaR = sqrt(deltaR2(aPat,otherMu));
+          float estimator = deltaR/(aPat.pt()*aPat.pt());
+          if (estimator<minEstimator){
+            minEstimator=estimator;
+            minIte = m;
+          }
+        }
+        //cout << "at this point " << minEstimator << " " << minIte << endl;
+        listOfFSRphoton.push_back(listOfFSRphotonForThisMuon.at(minIte));
+      }
+      else if (listOfFSRphotonForThisMuon.size()==1){
+        listOfFSRphoton.push_back(listOfFSRphotonForThisMuon.at(0));
+      }
+    }
+    float thePFvalue = 0;
+    for (unsigned int itePat=0 ; itePat<thePFparticles.size(); itePat++){
+      pat::PackedCandidate aPat = thePFparticles.at(itePat);
+      if (!(fabs(aPat.pdgId())==22)) continue;
+      bool isAnFSRPhoton=false;
+
+      float deltaR = deltaR2(aPat,theMuon);
+
+      if (deltaR>(coneSize*coneSize)) continue;
+
+      for (unsigned int m=0 ; m<listOfFSRphoton.size() ; m++){
+        if (itePat==listOfFSRphoton.at(m)) isAnFSRPhoton=true;
+      }
+      if (isAnFSRPhoton) continue;
+      if (deltaR<(0.01*0.01)) continue;
+      if (aPat.pt()<threshold) continue;
+      thePFvalue=thePFvalue+aPat.pt();
+    }
+    return thePFvalue;
+  }
+
   bool passId (VersionedPatElectronSelector id, edm::EventBase const & event, pat::Electron el){
     // This assumes an object to be created ( *before the event loop* ):
     // VersionedPatElectronSelector loose_id("some_VID_tag_including_the_WP");
     return id(el, event);
   }
-  
+
   bool passId(pat::Electron& el,  reco::Vertex& vtx, int IdLevel, int cutVersion){
-    
-    //for electron Id look here: //https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Spring15_selection_25ns 
+
+    //for electron Id look here: //https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Spring15_selection_25ns
     //for the meaning of the different cuts here: https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammaCutBasedIdentification
     float dEtaln         = fabs(el.deltaEtaSuperClusterTrackAtVtx());
     float dPhiln         = fabs(el.deltaPhiSuperClusterTrackAtVtx());
@@ -21,13 +90,13 @@ namespace patUtils
     float hem            = el.hadronicOverEm();
     double resol         = fabs((1/el.ecalEnergy())-(el.eSuperClusterOverP()/el.ecalEnergy()));
     double dxy           = fabs(el.gsfTrack()->dxy(vtx.position()));
-    double dz            = fabs(el.gsfTrack()->dz(vtx.position())); 
+    double dz            = fabs(el.gsfTrack()->dz(vtx.position()));
     double mHits         = el.gsfTrack()->hitPattern().numberOfHits(reco::HitPattern::MISSING_INNER_HITS);
-    bool conversionVeto = el.passConversionVeto(); 
+    bool conversionVeto = el.passConversionVeto();
     bool barrel = (fabs(el.superCluster()->eta()) <= 1.479);
     bool endcap = (!barrel && fabs(el.superCluster()->eta()) < 2.5);
-    
-    // Spring15 selection 
+
+    // Spring15 selection
     switch(cutVersion){
     case CutVersion::Spring15Cut25ns :
 
@@ -56,7 +125,7 @@ namespace patUtils
                  conversionVeto            )
                 return true;
         	break;
-              
+
               case llvvElecId::Loose :
               if(barrel                   &&
                  dEtaln        < 0.0105   &&
@@ -81,7 +150,7 @@ namespace patUtils
                  conversionVeto            )
                 return true;
               break;
-        
+
             case llvvElecId::Medium :
               if(barrel                     &&
                  dEtaln          < 0.0103   &&
@@ -106,7 +175,7 @@ namespace patUtils
                  conversionVeto             )
                 return true;
               break;
-        
+
             case llvvElecId::Tight :
               if(barrel                     &&
                  dEtaln          < 0.00926  &&
@@ -131,14 +200,14 @@ namespace patUtils
                  conversionVeto             )
                 return true;
               break;
-        
+
             case llvvElecId::LooseMVA :
             case llvvElecId::MediumMVA :
             case llvvElecId::TightMVA :
               printf("FIXME: MVA ID not yet implemented for the electron\n");
               return false;
                           break;
-                          
+
             default:
               printf("FIXME ElectronId llvvElecId::%i is unkown\n", IdLevel);
               return false;
@@ -174,7 +243,7 @@ namespace patUtils
                  conversionVeto            )
                 return true;
         	break;
-              
+
               case llvvElecId::Loose :
               if(barrel                   &&
                  dEtaln        < 0.00477  &&
@@ -199,7 +268,7 @@ namespace patUtils
                  conversionVeto            )
                 return true;
               break;
-        
+
             case llvvElecId::Medium :
               if(barrel                     &&
                  dEtaln          < 0.00311  &&
@@ -224,7 +293,7 @@ namespace patUtils
                  conversionVeto             )
                 return true;
               break;
-        
+
             case llvvElecId::Tight :
               if(barrel                     &&
                  dEtaln          < 0.00308  &&
@@ -249,14 +318,14 @@ namespace patUtils
                  conversionVeto             )
                 return true;
               break;
-        
+
             case llvvElecId::LooseMVA :
             case llvvElecId::MediumMVA :
             case llvvElecId::TightMVA :
               printf("FIXME: MVA ID not yet implemented for the electron\n");
               return false;
                           break;
-                          
+
             default:
               printf("FIXME ElectronId llvvElecId::%i is unkown\n", IdLevel);
               return false;
@@ -271,43 +340,43 @@ namespace patUtils
     }
     return false;
   }
-  
+
   bool passId(pat::Muon& mu,  reco::Vertex& vtx, int IdLevel, int cutVersion){
     //for muon Id look here: https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMuonId#LooseMuon
-   
-    // Spring15 selection 
+
+    // Spring15 selection
     switch(cutVersion){
     case CutVersion::Spring15Cut25ns :
 
             switch(IdLevel){
-              
+
             case llvvMuonId::Loose :
               if(mu.isPFMuon() && (mu.isGlobalMuon() || mu.isTrackerMuon()))return true;
               break;
-              
+
             case llvvMuonId::Soft :
               if(mu.isPFMuon() && mu.isTrackerMuon() && mu.muonID("TMOneStationTight") && mu.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 && mu.innerTrack()->hitPattern().pixelLayersWithMeasurement() > 1 &&
                  fabs(mu.innerTrack()->dxy(vtx.position())) < 0.3 && fabs(mu.innerTrack()->dz(vtx.position())) < 20. && mu.innerTrack()->normalizedChi2() < 1.8) return true;
               break;
-              
+
             case llvvMuonId::Tight :
               if( mu.isPFMuon() && mu.isGlobalMuon() && mu.globalTrack()->normalizedChi2() < 10. && mu.globalTrack()->hitPattern().numberOfValidMuonHits() > 0. && mu.numberOfMatchedStations() > 1 &&
                   fabs(mu.muonBestTrack()->dxy(vtx.position())) < 0.2 && fabs(mu.muonBestTrack()->dz(vtx.position())) < 0.5 && mu.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 &&
                   mu.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5)return true;
               break;
-              
+
             case llvvMuonId::StdLoose :
               if(mu.isLooseMuon()) return true;
               break;
-              
+
             case llvvMuonId::StdSoft :
               if(mu.isSoftMuon(vtx)) return true;
               break;
-              
+
             case llvvMuonId::StdTight :
               if(mu.isTightMuon(vtx)) return true;
               break;
-              
+
             default:
               printf("FIXME MuonId llvvMuonId::%i is unkown\n", IdLevel);
               return false;
@@ -317,18 +386,18 @@ namespace patUtils
 	// ICHEP16 or Moriond17 selection
     case CutVersion::Moriond17Cut :
     case CutVersion::ICHEP16Cut :
-        
+
             switch(IdLevel){
-              
+
             case llvvMuonId::Loose :
               if(mu.isPFMuon() && (mu.isGlobalMuon() || mu.isTrackerMuon()))return true;
               break;
-              
+
             case llvvMuonId::Soft :
               if(muon::isGoodMuon(mu, muon::TMOneStationTight) && mu.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 && mu.innerTrack()->hitPattern().pixelLayersWithMeasurement() > 0 &&
                  fabs(mu.innerTrack()->dxy(vtx.position())) < 0.3 && fabs(mu.innerTrack()->dz(vtx.position())) < 20.) return true;
               break;
-              
+
             case llvvMuonId::Tight :
               if( mu.isPFMuon() && mu.isGlobalMuon() && mu.globalTrack()->normalizedChi2() < 10. && mu.globalTrack()->hitPattern().numberOfValidMuonHits() > 0. && mu.numberOfMatchedStations() > 1 &&
                   fabs(mu.muonBestTrack()->dxy(vtx.position())) < 0.2 && fabs(mu.muonBestTrack()->dz(vtx.position())) < 0.5 && mu.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 &&
@@ -340,22 +409,22 @@ namespace patUtils
               break;
             case llvvMuonId::TightAndTlkHighPt :
 	      {
-	      bool tightID =  mu.isPFMuon() && mu.isGlobalMuon() && mu.globalTrack()->normalizedChi2() < 10. && mu.globalTrack()->hitPattern().numberOfValidMuonHits() > 0. && mu.numberOfMatchedStations() > 1 && fabs(mu.muonBestTrack()->dxy(vtx.position())) < 0.2 && fabs(mu.muonBestTrack()->dz(vtx.position())) < 0.5 && mu.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 && mu.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5; 
+	      bool tightID =  mu.isPFMuon() && mu.isGlobalMuon() && mu.globalTrack()->normalizedChi2() < 10. && mu.globalTrack()->hitPattern().numberOfValidMuonHits() > 0. && mu.numberOfMatchedStations() > 1 && fabs(mu.muonBestTrack()->dxy(vtx.position())) < 0.2 && fabs(mu.muonBestTrack()->dz(vtx.position())) < 0.5 && mu.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 && mu.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5;
               bool tkHighPt = mu.isTrackerMuon() && mu.track().isNonnull() && mu.numberOfMatchedStations() > 1 && (mu.muonBestTrack()->ptError()/mu.muonBestTrack()->pt()) < 0.3 && fabs(mu.muonBestTrack()->dxy(vtx.position()))<0.2 && fabs(mu.muonBestTrack()->dz(vtx.position())) < 0.5 && mu.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 && mu.innerTrack()->hitPattern().trackerLayersWithMeasurement()>5;
               if (tightID||(mu.pt()>200&&tkHighPt)) return true;
               }
             case llvvMuonId::StdLoose :
               if(mu.isLooseMuon()) return true;
               break;
-              
+
             case llvvMuonId::StdSoft :
               if(mu.isSoftMuon(vtx)) return true;
               break;
-              
+
             case llvvMuonId::StdTight :
               if(mu.isTightMuon(vtx)) return true;
               break;
-              
+
             default:
               printf("FIXME MuonId llvvMuonId::%i is unkown\n", IdLevel);
               return false;
@@ -369,27 +438,27 @@ namespace patUtils
     }
 
     return false;
-  }  
-  
+  }
+
   bool passId(pat::Photon& photon, double rho, int IdLevel){
     // https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedPhotonIdentificationRun2
-    // CSA14 selection, conditions: 25ns, better detector alignment. 
-    // Used Savvas Kyriacou's slides, mailed from Ilya. 
-    
+    // CSA14 selection, conditions: 25ns, better detector alignment.
+    // Used Savvas Kyriacou's slides, mailed from Ilya.
+
     bool elevto = photon.hasPixelSeed();  //LQ  REACTIVATED FOR TIGHT ID, OTHERWISE MANY ELECtRONS pass the photon Id
-    
+
     // sigma ieta ieta in 5x5 shower block
      float sigmaIetaIeta = photon.full5x5_sigmaIetaIeta();
 
-    // H/E 
+    // H/E
     float hoe = photon.hadTowOverEm();
 
     // isolation
     double pt=photon.pt();
     double eta=photon.superCluster()->eta();
 
-    float chIso = photon.chargedHadronIso(); 
-    float chArea = utils::cmssw::getEffectiveArea(22,eta,"chIso"); 
+    float chIso = photon.chargedHadronIso();
+    float chArea = utils::cmssw::getEffectiveArea(22,eta,"chIso");
 
     float nhIso = photon.neutralHadronIso();
     float nhArea = utils::cmssw::getEffectiveArea(22,eta,"nhIso");
@@ -403,7 +472,7 @@ namespace patUtils
     //SPRING16 selection :  https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedPhotonIdentificationRun2#Recommended_Working_points_for_2
           switch(IdLevel){
           case llvvPhotonId::Loose :
-              
+
             if ( barrel
       	   //&& !elevto
       	   && hoe < 0.0597
@@ -411,7 +480,7 @@ namespace patUtils
       	   && TMath::Max(chIso-chArea*rho,0.0) < 1.295
       	   && TMath::Max(nhIso-nhArea*rho,0.0) < 10.910 + 0.0148*pt + 0.000017*pt*pt
       	   && TMath::Max(gIso-gArea*rho,  0.0) < 3.630 + 0.0047*pt  )
-      	return true; 
+      	return true;
             if ( endcap
       	   //&& !elevto
       	   && hoe < 0.0481
@@ -419,20 +488,20 @@ namespace patUtils
       	   && TMath::Max(chIso-chArea*rho,0.0) < 1.011
       	   && TMath::Max(nhIso-nhArea*rho,0.0) < 5.931 + 0.0163*pt+0.000014*pt*pt
       	   && TMath::Max(gIso-gArea*rho,  0.0) < 6.641 + 0.0034*pt  )
-      	return true; 
-                  
+      	return true;
+
             break;
-            
+
           case llvvPhotonId::Medium :
-      
+
             if ( barrel
       	   //&& !elevto
       	   && hoe < 0.0396
       	   && sigmaIetaIeta < 0.01022
-      	   && TMath::Max(chIso-chArea*rho,0.0) < 0.441 
-      	   && TMath::Max(nhIso-nhArea*rho,0.0) < 2.725 + 0.0148*pt + 0.000017*pt*pt 
+      	   && TMath::Max(chIso-chArea*rho,0.0) < 0.441
+      	   && TMath::Max(nhIso-nhArea*rho,0.0) < 2.725 + 0.0148*pt + 0.000017*pt*pt
       	   && TMath::Max(gIso-gArea*rho,  0.0) < 2.571 + 0.0047*pt  )
-      	return true; 
+      	return true;
             if ( endcap
       	   //&& !elevto
       	   && hoe < 0.0219
@@ -440,72 +509,72 @@ namespace patUtils
       	   && TMath::Max(chIso-chArea*rho,0.0) < 0.442
       	   && TMath::Max(nhIso-nhArea*rho,0.0) < 1.715 + 0.0163*pt+0.000014*pt*pt
       	   && TMath::Max(gIso-gArea*rho,  0.0) < 3.863 + 0.0034*pt  )
-      	return true; 
-                  
+      	return true;
+
             break;
           case llvvPhotonId::Tight :
-            
-            if ( barrel   
-           && !elevto 
-      	   && hoe < 0.0269      
+
+            if ( barrel
+           && !elevto
+      	   && hoe < 0.0269
            && sigmaIetaIeta < 0.00994
       	   && TMath::Max(chIso-chArea*rho,0.0) < 0.202
       	   && TMath::Max(nhIso-nhArea*rho,0.0) < 0.264 + 0.0148*pt+0.000017*pt*pt
       	   && TMath::Max(gIso-gArea*rho,  0.0) < 2.362 + 0.0047*pt )
       	return true;
-      
+
             if ( endcap
-           && !elevto 
-      	   && hoe < 0.0213 
+           && !elevto
+      	   && hoe < 0.0213
       	   && sigmaIetaIeta < 0.03000
-      	   && TMath::Max(chIso-chArea*rho,0.0) < 0.034 
+      	   && TMath::Max(chIso-chArea*rho,0.0) < 0.034
       	   && TMath::Max(nhIso-nhArea*rho,0.0) < 0.586 + 0.0163*pt + 0.000014*pt*pt
-      	   && TMath::Max(gIso-gArea*rho,  0.0) < 2.617 + 0.0034*pt ) 
-      	return true; 
-      break;          
+      	   && TMath::Max(gIso-gArea*rho,  0.0) < 2.617 + 0.0034*pt )
+      	return true;
+      break;
 
     default:
       printf("FIXME PhotonId llvvPhotonId::%i is unkown\n", IdLevel);
       return false;
       break;
-      
-    }    
-    
-    return false; 
+
+    }
+
+    return false;
   }
 
   float relIso(patUtils::GenericLepton& lep, double rho){
-    
+
     int lid=lep.pdgId();
-    float relIso = 0.0; 
-      
+    float relIso = 0.0;
+
     if(lid==13){
 
       float  chIso   = lep.mu.pfIsolationR04().sumChargedHadronPt;
       float  nhIso   = lep.mu.pfIsolationR04().sumNeutralHadronEt;
       float  gIso    = lep.mu.pfIsolationR04().sumPhotonEt;
       float  puchIso = lep.mu.pfIsolationR04().sumPUPt;
-      
+
       relIso  = (chIso + TMath::Max(0.,nhIso+gIso-0.5*puchIso)) / lep.mu.pt();
-      
-    } else if (lid==11){ 
-      
+
+    } else if (lid==11){
+
       //https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Spring15_selection_25ns
       float  chIso   = lep.el.pfIsolationVariables().sumChargedHadronPt;
       float  nhIso   = lep.el.pfIsolationVariables().sumNeutralHadronEt;
       float  gIso    = lep.el.pfIsolationVariables().sumPhotonEt;
-        
+
       if (rho == 0) {
-	float  puchIso = lep.el.pfIsolationVariables().sumPUPt; 
+	float  puchIso = lep.el.pfIsolationVariables().sumPUPt;
 	relIso  = (chIso + TMath::Max(0.,nhIso+gIso-0.5*puchIso)) / lep.el.pt();
       }
       else {
 	float effArea = utils::cmssw::getEffectiveArea(11,lep.el.superCluster()->eta());
 	relIso  = (chIso + TMath::Max(0.,nhIso+gIso-rho*effArea)) / lep.el.pt();
       }
-      
+
     }
-    
+
     return relIso;
 
   }
@@ -516,27 +585,27 @@ namespace patUtils
     // VersionedPatElectronSelector loose_id("some_VID_tag_including_the_WP");
     return true; // Isolation is now embedded into the ID.
   }
-  
+
   bool passIso(pat::Electron& el, int IsoLevel, int cutVersion, double rho  ){
          //https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Spring15_selection_25ns
 	  float  chIso   = el.pfIsolationVariables().sumChargedHadronPt;
           float  nhIso   = el.pfIsolationVariables().sumNeutralHadronEt;
           float  gIso    = el.pfIsolationVariables().sumPhotonEt;
 
-	  float  relIso = 0.0; 
-	  
+	  float  relIso = 0.0;
+
 	  if (rho == 0) {
-	    float  puchIso = el.pfIsolationVariables().sumPUPt; 
+	    float  puchIso = el.pfIsolationVariables().sumPUPt;
 	    relIso  = (chIso + TMath::Max(0.,nhIso+gIso-0.5*puchIso)) / el.pt();
 	  }
 	  else {
 	    float effArea = utils::cmssw::getEffectiveArea(11,el.superCluster()->eta());
 	    relIso  = (chIso + TMath::Max(0.,nhIso+gIso-rho*effArea)) / el.pt();
 	  }
-	  
+
           bool barrel = (fabs(el.superCluster()->eta()) <= 1.479);
           bool endcap = (!barrel && fabs(el.superCluster()->eta()) < 2.5);
-          // Spring15 selection 
+          // Spring15 selection
           switch(cutVersion){
           case CutVersion::Spring15Cut25ns :
       	  // Spring15 selection, conditions: PU20 bx25
@@ -545,29 +614,29 @@ namespace patUtils
                         if( barrel && relIso < 0.126    ) return true;
                         if( endcap && relIso < 0.144    ) return true;
                         break;
-      
+
                      case llvvElecIso::Loose :
                         if( barrel && relIso < 0.0893   ) return true;
                         if( endcap && relIso < 0.121    ) return true;
                         break;
-      
+
                      case llvvElecIso::Medium :
                         if( barrel && relIso < 0.0766   ) return true;
                         if( endcap && relIso < 0.0678   ) return true;
                         break;
-      
+
                      case llvvElecIso::Tight :
                         if( barrel && relIso < 0.0354   ) return true;
                         if( endcap && relIso < 0.0646   ) return true;
                         break;
-      
+
                      default:
                         printf("FIXME ElectronIso llvvElectronIso::%i is unkown\n", IsoLevel);
                         return false;
                         break;
                 }
              break;
-      
+
           case CutVersion::Moriond17Cut :
           case CutVersion::ICHEP16Cut :
       	  // ICHEP16 or Moriond17 selection, conditions: PU20 bx25
@@ -576,22 +645,22 @@ namespace patUtils
                         if( barrel && relIso < 0.175    ) return true;
                         if( endcap && relIso < 0.159    ) return true;
                         break;
-      
+
                      case llvvElecIso::Loose :
                         if( barrel && relIso < 0.0994   ) return true;
                         if( endcap && relIso < 0.107    ) return true;
                         break;
-      
+
                      case llvvElecIso::Medium :
                         if( barrel && relIso < 0.0695   ) return true;
                         if( endcap && relIso < 0.0821   ) return true;
                         break;
-      
+
                      case llvvElecIso::Tight :
                         if( barrel && relIso < 0.0588   ) return true;
                         if( endcap && relIso < 0.0571   ) return true;
                         break;
-      
+
                      default:
                         printf("FIXME ElectronIso llvvElectronIso::%i is unkown\n", IsoLevel);
                         return false;
@@ -606,9 +675,9 @@ namespace patUtils
 
 	  }
 
-          return false;  
+          return false;
    }
-  
+
   bool passIso(pat::Muon& mu, int IsoLevel, int cutVersion){
     //https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMuonId#Muon_Isolation
     float  chIso   = mu.pfIsolationR04().sumChargedHadronPt;
@@ -622,18 +691,18 @@ namespace patUtils
     float  puchIso03 = mu.pfIsolationR03().sumPUPt;
     float  relIso03  = (chIso03 + TMath::Max(0.,nhIso03+gIso03-0.5*puchIso03)) / mu.pt();
     float  trkrelIso = mu.isolationR03().sumPt/mu.pt(); // no PU correction
-    
+
     switch(cutVersion){
        case CutVersion::Spring15Cut25ns :
            switch(IsoLevel){
-              case llvvMuonIso::Loose : 
+              case llvvMuonIso::Loose :
                  if( relIso < 0.20 ) return true;
                  break;
-               	 
+
               case llvvMuonIso::Tight :
                 if( relIso < 0.15 ) return true;
                 break;
-             
+
               default:
                 printf("FIXME MuonIso llvvMuonIso::%i is unkown\n", IsoLevel);
                 return false;
@@ -642,14 +711,14 @@ namespace patUtils
            break;
        case CutVersion::ICHEP16Cut :
            switch(IsoLevel){
-              case llvvMuonIso::Loose : 
+              case llvvMuonIso::Loose :
                  if( relIso < 0.20 && trkrelIso < 0.1) return true;
                  break;
-               	 
+
               case llvvMuonIso::Tight :
                 if( relIso < 0.15 && trkrelIso < 0.1) return true;
                 break;
-             
+
               default:
                 printf("FIXME MuonIso llvvMuonIso::%i is unkown\n", IsoLevel);
                 return false;
@@ -659,10 +728,10 @@ namespace patUtils
 
        case CutVersion::Moriond17Cut :
            switch(IsoLevel){
-              case llvvMuonIso::Loose : 
+              case llvvMuonIso::Loose :
                  if( relIso < 0.25 ) return true;
                  break;
-               	 
+
               case llvvMuonIso::Tight :
                 if( relIso < 0.15 ) return true;
                 break;
@@ -682,8 +751,149 @@ namespace patUtils
            break;
     }
 
-    return false;          
+    return false;
   }
+
+  bool passIso(pat::Muon& mu, int IsoLevel, int cutVersion, std::vector<pat::PackedCandidate> thePats, pat::MuonCollection muons, reco::Vertex& vertex ){
+  //https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMuonId#Muon_Isolation
+  float  chIso   = mu.pfIsolationR04().sumChargedHadronPt;
+  float  nhIso   = mu.pfIsolationR04().sumNeutralHadronEt;
+  float  gIso    = mu.pfIsolationR04().sumPhotonEt;
+  float  puchIso = mu.pfIsolationR04().sumPUPt;
+  float  relIso  = (chIso + TMath::Max(0.,nhIso+gIso-0.5*puchIso)) / mu.pt();
+  float  chIso03   = mu.pfIsolationR03().sumChargedHadronPt;
+  float  nhIso03   = mu.pfIsolationR03().sumNeutralHadronEt;
+  //float  gIso03    = mu.pfIsolationR03().sumPhotonEt;
+  float  puchIso03 = mu.pfIsolationR03().sumPUPt;
+  float gIso03H4l = computePFphotonIsolation(thePats, 0.3, 0., mu, muons, vertex);
+  float  relIso03  = (chIso03 + TMath::Max(0.,nhIso03+gIso03H4l-0.5*puchIso03)) / mu.pt();
+  float  trkrelIso = mu.isolationR03().sumPt/mu.pt(); // no PU correction
+
+  float trkrelIsoCloseByCleanned =  makeTkIsoCloseBySafe( 0.3, mu.isolationR03().sumPt, mu, muons)/mu.pt();
+
+
+  float chHadPtToRemove=0;
+  float ntHadPtToRemove=0;
+  float pfPhotonToRemove=0;
+  ///checkMuonInCone
+  for (unsigned int j = 0; j < muons.size(); ++j) {
+      pat::Muon &otherMu = muons.at(j);
+      if (deltaR2(mu, otherMu)==0) continue;
+      if (!(patUtils::passId(otherMu, vertex, patUtils::llvvMuonId::tkHighPT, patUtils::CutVersion::ICHEP16Cut))) continue;
+      //if (otherMu.isPFMuon()) continue;
+      if (deltaR2(mu,otherMu) < 0.16){
+        if (patUtils::passId(mu, vertex, patUtils::llvvMuonId::tkHighPT, patUtils::CutVersion::ICHEP16Cut)){
+          /*std::cout << "hi, found a second muon in the cone" << std::endl;
+          std::cout << "first muon pt" << mu.pt() << " " <<  mu.eta()  << " "<< mu.isPFMuon() << endl;
+          std::cout << "second muon pt " << otherMu.pt() << " " << otherMu.eta() << " " << otherMu.isPFMuon() << endl;*/
+          /*float minDr=100;
+          float minDrMain=100;
+          //  float secMin=100;
+          int iteParticle = -1;
+          int iteParticleMain = -1;*/
+
+          for (unsigned int itePat=0 ; itePat<thePats.size(); itePat++){
+            pat::PackedCandidate aPat = thePats.at(itePat);
+            if (fabs(aPat.pdgId())==13) continue;
+            float deltaR = deltaR2(aPat,otherMu);
+            float deltaRMu = deltaR2(aPat,mu);
+            if (deltaR<0.16){
+              //cout << "pt=" << aPat.pt() << " pdgID=" << aPat.pdgId() << " deltaR=" << deltaR  << " deltaOther=" << deltaRMu<< endl;
+              if ((deltaR<0.0001)&&(!otherMu.isPFMuon())&&(fabs(aPat.pdgId())==211)){
+                chHadPtToRemove = chHadPtToRemove+aPat.pt();
+              }
+              if ((deltaR<0.001)&&(fabs(aPat.pdgId())==130)){
+                ntHadPtToRemove = ntHadPtToRemove+ aPat.pt();
+              }
+              if ((deltaR<0.01)&&(fabs(aPat.pdgId())==22)){
+                pfPhotonToRemove =  pfPhotonToRemove+ aPat.pt();
+              }
+              //cout << "status iso before=" << pfIso04.sumPhotonEt-pfPhotonToRemove-aPat.pt() << " deltaR=" << deltaRMu << endl;
+              if ((deltaRMu<0.001)&&(fabs(aPat.pdgId())==22)&&((mu.pfIsolationR04().sumPhotonEt-pfPhotonToRemove-aPat.pt())>-10)){
+                //cout << "hello inside " << endl;
+                pfPhotonToRemove =  pfPhotonToRemove+ aPat.pt();
+              }
+              //cout << "status iso before=" << pfIso04.sumNeutralHadronEt-ntHadPtToRemove-aPat.pt() << " deltaR=" << deltaRMu << endl;
+              if ((deltaRMu<0.001)&&(fabs(aPat.pdgId())==130)&&((mu.pfIsolationR04().sumNeutralHadronEt-ntHadPtToRemove-aPat.pt())>-10)){
+                //cout << "hello inside " << endl;
+                ntHadPtToRemove = ntHadPtToRemove+ aPat.pt();
+              }
+            }
+
+          }
+
+        }
+      }
+  }
+  float relIsoSafeCloseBy = (mu.pfIsolationR04().sumChargedHadronPt  - chHadPtToRemove +
+            std::max(0.,mu.pfIsolationR04().sumPhotonEt+mu.pfIsolationR04().sumNeutralHadronEt - pfPhotonToRemove - ntHadPtToRemove - 0.5*mu.pfIsolationR04().sumPUPt)) / mu.pt();
+  switch(cutVersion){
+     case CutVersion::Spring15Cut25ns :
+         switch(IsoLevel){
+            case llvvMuonIso::Loose :
+               if( relIso < 0.20 ) return true;
+               break;
+
+            case llvvMuonIso::Tight :
+              if( relIso < 0.15 ) return true;
+              break;
+
+            default:
+              printf("FIXME MuonIso llvvMuonIso::%i is unkown\n", IsoLevel);
+              return false;
+              break;
+         }
+         break;
+     case CutVersion::ICHEP16Cut :
+         switch(IsoLevel){
+            case llvvMuonIso::Loose :
+               if( relIso < 0.20 && trkrelIso < 0.1) return true;
+               break;
+
+            case llvvMuonIso::Tight :
+              if( relIso < 0.15 && trkrelIso < 0.1) return true;
+              break;
+
+            default:
+              printf("FIXME MuonIso llvvMuonIso::%i is unkown\n", IsoLevel);
+              return false;
+              break;
+         }
+         break;
+
+     case CutVersion::Moriond17Cut :
+         switch(IsoLevel){
+            case llvvMuonIso::Loose :
+               if( relIso < 0.25 ) return true;
+               break;
+
+            case llvvMuonIso::Tight :
+              if( relIso < 0.15 ) return true;
+              break;
+            case llvvMuonIso::H4lWP :
+              if( relIso03 < 0.35 ) return true;
+              break;
+            case llvvMuonIso::TightBoosted:
+              if (relIsoSafeCloseBy < 0.15) return true;
+              break;
+              case llvvMuonIso::TightAndTkRelatBoosted:
+                if (relIsoSafeCloseBy < 0.15 && trkrelIsoCloseByCleanned < 0.1) return true;
+                break;
+            default:
+              printf("FIXME MuonIso llvvMuonIso::%i is unkown\n", IsoLevel);
+              return false;
+              break;
+         }
+         break;
+
+     default:
+         printf("FIXME MuonIsolation  CutVersion::%i is unkown\n", cutVersion);
+         return false;
+         break;
+  }
+
+  return false;
+}
 
   bool passPhotonTrigger(fwlite::Event &ev, float &triggerThreshold, float &triggerPrescale, float& triggerThresholdHigh ){
     edm::TriggerResultsByName tr = ev.triggerResultsByName("HLT");
@@ -691,10 +901,10 @@ namespace patUtils
 
     bool hasPhotonTrigger(false);
 
-    triggerPrescale = 1.0; 
+    triggerPrescale = 1.0;
     triggerThreshold = 0.0;
     triggerThresholdHigh = 999999;
-    
+
 
     std::string successfulPath="";
     if( utils::passTriggerPatternsAndGetName(tr, successfulPath, "HLT_Photon300_*")){
@@ -737,17 +947,17 @@ namespace patUtils
       triggerThreshold=36;
       triggerThresholdHigh=50;
     }
-    else if(utils::passTriggerPatternsAndGetName(tr, successfulPath, "HLT_Photon30_R9Id90_HE10_IsoM_*")){ //HE10_Iso40_EBOnly_*")){                       
-      hasPhotonTrigger=true;                                                                                                                     
-      triggerThreshold=30;    
+    else if(utils::passTriggerPatternsAndGetName(tr, successfulPath, "HLT_Photon30_R9Id90_HE10_IsoM_*")){ //HE10_Iso40_EBOnly_*")){
+      hasPhotonTrigger=true;
+      triggerThreshold=30;
       triggerThresholdHigh=36;
-    } 
+    }
     else if(utils::passTriggerPatternsAndGetName(tr, successfulPath, "HLT_Photon22_R9Id90_HE10_IsoM_*")){ //HE10_Iso40_EBOnly_*")){
       hasPhotonTrigger=true;
       triggerThreshold=22;
       triggerThresholdHigh=30;
     }
-      
+
     if(successfulPath!=""){ //get the prescale associated to it
       fwlite::Handle< pat::PackedTriggerPrescales > prescalesHandle;
       prescalesHandle.getByLabel(ev, "patTrigger");
@@ -757,21 +967,21 @@ namespace patUtils
       triggerPrescale = prescales.getPrescaleForName(successfulPath);
     }
 
-    return hasPhotonTrigger; 
+    return hasPhotonTrigger;
   }
 
-  
+
   bool passVBFPhotonTrigger(fwlite::Event &ev, float &triggerThreshold,
 			    float &triggerPrescale, float &triggerThresholdHigh ){
     edm::TriggerResultsByName tr = ev.triggerResultsByName("HLT");
     if( !tr.isValid() ) return false;
 
     bool hasPhotonTrigger(false);
-    // float triggerPrescale(1.0); 
+    // float triggerPrescale(1.0);
     // float triggerThreshold(0);
-    triggerPrescale = 1.0; 
+    triggerPrescale = 1.0;
     triggerThreshold = 0.0;
-    triggerThresholdHigh = 999999; 
+    triggerThresholdHigh = 999999;
 
     std::string successfulPath="";
     if( utils::passTriggerPatternsAndGetName(tr, successfulPath, "HLT_Photon300_*")){
@@ -782,7 +992,7 @@ namespace patUtils
     else if( utils::passTriggerPatternsAndGetName(tr, successfulPath, "HLT_Photon250_*")){
       hasPhotonTrigger=true;
       triggerThreshold=250;
-      triggerThresholdHigh=300; 
+      triggerThresholdHigh=300;
     }
     else if( utils::passTriggerPatternsAndGetName(tr, successfulPath, "HLT_Photon120_R9Id90_HE10_Iso40_EBOnly_VBF_*")){
       hasPhotonTrigger=true;
@@ -814,7 +1024,7 @@ namespace patUtils
       triggerThreshold=22;
       triggerThresholdHigh=36;
     }
-      
+
     if(successfulPath!=""){ //get the prescale associated to it
       fwlite::Handle< pat::PackedTriggerPrescales > prescalesHandle;
       prescalesHandle.getByLabel(ev, "patTrigger");
@@ -824,9 +1034,9 @@ namespace patUtils
       triggerPrescale = prescales.getPrescaleForName(successfulPath);
     }
 
-    return hasPhotonTrigger; 
+    return hasPhotonTrigger;
   }
-  
+
 
   bool passPFJetID(std::string label,
                   pat::Jet jet){
@@ -834,7 +1044,7 @@ namespace patUtils
     bool passID = false;
 
     float rawJetEn(jet.correctedJet("Uncorrected").energy() );
-    // Note: All fractions are calculated with the raw/uncorrected energy of the jet (only then they add up to unity). So the PF JetID has to be applied before the jet energy corrections. 
+    // Note: All fractions are calculated with the raw/uncorrected energy of the jet (only then they add up to unity). So the PF JetID has to be applied before the jet energy corrections.
 
     float nhf( (jet.neutralHadronEnergy() + jet.HFHadronEnergy())/rawJetEn );
     float nef( jet.neutralEmEnergy()/rawJetEn );
@@ -851,7 +1061,7 @@ namespace patUtils
       if( fabs(jet.eta()) > 2.7 && fabs(jet.eta()) <= 3.0) passID = ( nef>0.01 && nhf<0.98 && NumNeutralParticles > 2);
       if( fabs(jet.eta()) > 3.0) passID = (nef<0.90 && NumNeutralParticles > 10);
     }
-    if (label == "Tight"){ 
+    if (label == "Tight"){
       if( fabs(jet.eta()) <= 2.7) passID = ( (nhf<0.90  && nef<0.90 && nconst>1) && ( fabs(jet.eta())>2.4 || (fabs(jet.eta()) <= 2.4 && chf>0 && nch>0 && cef<0.99) ) );
       if( fabs(jet.eta()) > 2.7 && fabs(jet.eta()) <= 3.0) passID = ( nef>0.01 && nhf<0.98 && NumNeutralParticles > 2);
       if( fabs(jet.eta()) > 3.0) passID = (nef<0.90 && NumNeutralParticles > 10);
@@ -896,7 +1106,7 @@ namespace patUtils
   bool exclusiveDataEventFilter(const double& run, const bool& isMC, const bool& isPromptReco)
   {
     bool passExclusiveDataEventFilter(false);
-    
+
     if(isMC)
       passExclusiveDataEventFilter=true;
     else
@@ -923,7 +1133,7 @@ void MetFilter::FillBadEvents(std::string path){
      std::ifstream File;
      File.open(path.c_str());
      if(!File.good() ){
-       std::cout<<"ERROR:: File "<<path<<" NOT FOUND!!"<<std::endl; 
+       std::cout<<"ERROR:: File "<<path<<" NOT FOUND!!"<<std::endl;
        return;
      }
 
@@ -937,63 +1147,63 @@ void MetFilter::FillBadEvents(std::string path){
     File.close();
 }
 
-  
+
   bool MetFilter::passBadPFMuonFilter(const fwlite::Event& ev) {
 
-    const bool debug_ = false; 
+    const bool debug_ = false;
 
     const int algo_ = 14;
-    //    const double minDZ_ = 0.1; 
-    const double minTrkPtError_ = 0.5; 
-    const double minMuPt_ = 100.; 
+    //    const double minDZ_ = 0.1;
+    const double minTrkPtError_ = 0.5;
+    const double minMuPt_ = 100.;
 
-    pat::MuonCollection muons; 
-    fwlite::Handle<pat::MuonCollection> muonsHandle; 
-    muonsHandle.getByLabel(ev, "slimmedMuons"); 
+    pat::MuonCollection muons;
+    fwlite::Handle<pat::MuonCollection> muonsHandle;
+    muonsHandle.getByLabel(ev, "slimmedMuons");
     if(muonsHandle.isValid()){ muons = *muonsHandle;}
 
-    pat::PackedCandidateCollection pfCandidates; 
+    pat::PackedCandidateCollection pfCandidates;
     fwlite::Handle<pat::PackedCandidateCollection> pfCandidatesHandle;
-    pfCandidatesHandle.getByLabel(ev,"packedPFCandidates"); 
+    pfCandidatesHandle.getByLabel(ev,"packedPFCandidates");
     if (pfCandidatesHandle.isValid()) { pfCandidates = *pfCandidatesHandle; }
 
     bool foundBadPFMuon = false;
 
     for ( unsigned i=0; i < muons.size(); ++i ) { // loop over all muons
-    
+
       const reco::Muon & muon = muons[i];
 
       reco::TrackRef innerMuonTrack = muon.innerTrack();
 
-      if ( innerMuonTrack.isNull() ) { 
-	if (debug_) cout<<"Skipping this muon because it has no inner track"<<endl; 
-	continue; 
+      if ( innerMuonTrack.isNull() ) {
+	if (debug_) cout<<"Skipping this muon because it has no inner track"<<endl;
+	continue;
       };
 
       if ( innerMuonTrack->pt() < minMuPt_) {
-	if (debug_) cout<<"Skipping this muon because inner track pt."<<endl; 
+	if (debug_) cout<<"Skipping this muon because inner track pt."<<endl;
 	continue;
       }
 
-      if ( innerMuonTrack->quality(reco::TrackBase::highPurity) ) { 
-	if (debug_) cout<<"Skipping this muon because inner track is high purity."<<endl; 
+      if ( innerMuonTrack->quality(reco::TrackBase::highPurity) ) {
+	if (debug_) cout<<"Skipping this muon because inner track is high purity."<<endl;
 	continue;
       }
 
       // Consider only muons with large relative pt error
       if (debug_) cout<<"Muon inner track pt rel err: "<<innerMuonTrack->ptError()/innerMuonTrack->pt()<<endl;
       if (not ( innerMuonTrack->ptError()/innerMuonTrack->pt() > minTrkPtError_ ) ) {
-	if (debug_) cout<<"Skipping this muon because seems well measured."<<endl; 
+	if (debug_) cout<<"Skipping this muon because seems well measured."<<endl;
 	continue;
       }
 
       // Consider only muons from muonSeededStepOutIn algo
       if (debug_) cout<<"Muon inner track original algo: "<<innerMuonTrack->originalAlgo() << endl;
       if (not ( innerMuonTrack->originalAlgo() == algo_  && innerMuonTrack->algo() == algo_ ) ) {
-	if (debug_) cout<<"Skipping this muon because is not coming from the muonSeededStepOutIn"<<endl; 
+	if (debug_) cout<<"Skipping this muon because is not coming from the muonSeededStepOutIn"<<endl;
 	continue;
       }
-    
+
       for ( unsigned j=0; j < pfCandidates.size(); ++j ) {
 	const reco::Candidate & pfCandidate = pfCandidates[j];
 	// look for pf muon
@@ -1031,12 +1241,12 @@ void MetFilter::FillBadEvents(std::string path){
     //    typedef View<reco::Muon> MuonView;
     pat::MuonCollection muons;
     fwlite::Handle<pat::MuonCollection> muonsHandle;
-    muonsHandle.getByLabel(ev, "slimmedMuons");                                                                                          
-    if(muonsHandle.isValid()){ muons = *muonsHandle;}  
+    muonsHandle.getByLabel(ev, "slimmedMuons");
+    if(muonsHandle.isValid()){ muons = *muonsHandle;}
 
     //reco::Candidate CandidateView;
     //    typedef View<reco::Candidate> CandidateView;
-    pat::PackedCandidateCollection pfCandidates; 
+    pat::PackedCandidateCollection pfCandidates;
     fwlite::Handle<pat::PackedCandidateCollection> pfCandidatesHandle;
     pfCandidatesHandle.getByLabel(ev,"packedPFCandidates");
     if (pfCandidatesHandle.isValid()) { pfCandidates = *pfCandidatesHandle; }
@@ -1051,18 +1261,18 @@ void MetFilter::FillBadEvents(std::string path){
 	reco::TrackRef innerMuonTrack = muon.innerTrack();
         if (debug_) cout<<"muon "<<muon.pt()<<endl;
 
-        if ( innerMuonTrack.isNull() ) { 
-	  if (debug_) cout<<"Skipping this muon because it has no inner track"<<endl; 
-	  continue; 
+        if ( innerMuonTrack.isNull() ) {
+	  if (debug_) cout<<"Skipping this muon because it has no inner track"<<endl;
+	  continue;
 	};
-        if ( innerMuonTrack->quality(reco::TrackBase::highPurity) ) { 
-	  if (debug_) cout<<"Skipping this muon because inner track is high purity."<<endl; 
+        if ( innerMuonTrack->quality(reco::TrackBase::highPurity) ) {
+	  if (debug_) cout<<"Skipping this muon because inner track is high purity."<<endl;
 	  continue;
         }
         // Consider only muons with large relative pt error
         if (debug_) cout<<"Muon inner track pt rel err: "<<innerMuonTrack->ptError()/innerMuonTrack->pt()<<endl;
         if (not ( innerMuonTrack->ptError()/innerMuonTrack->pt() > minMuonTrackRelErr_ ) ) {
-	  if (debug_) cout<<"Skipping this muon because seems well measured."<<endl; 
+	  if (debug_) cout<<"Skipping this muon because seems well measured."<<endl;
 	  continue;
         }
         for ( unsigned j=0; j < pfCandidates.size(); ++j ) {
@@ -1074,10 +1284,10 @@ void MetFilter::FillBadEvents(std::string path){
 	  if ( (debug_)  and (dr<0.5) ) cout<<" pt(it) "<<innerMuonTrack->pt()<<" candidate "<<pfCandidate.pt()<<" dr "<< dr
 					    <<" dpt "<<dpt<<endl;
 	  // require similar pt ( one sided ) and small dR
-	  if ( ( deltaR( innerMuonTrack->eta(), innerMuonTrack->phi(), pfCandidate.eta(), pfCandidate.phi() ) < maxDR_ ) 
+	  if ( ( deltaR( innerMuonTrack->eta(), innerMuonTrack->phi(), pfCandidate.eta(), pfCandidate.phi() ) < maxDR_ )
 	       and ( ( pfCandidate.pt() - innerMuonTrack->pt())/(0.5*(innerMuonTrack->pt() + pfCandidate.pt())) > minPtDiffRel_ ) ) {
 	    foundBadChargedCandidate = true;
-	    cout <<"found bad track!"<<endl; 
+	    cout <<"found bad track!"<<endl;
 	    break;
 	  }
         }
@@ -1091,41 +1301,41 @@ void MetFilter::FillBadEvents(std::string path){
     return pass;
 
   }
-  
+
 
   int MetFilter::passMetFilterInt(const fwlite::Event& ev, bool is2016){
-  
-    if(map.find( RuLuEv(ev.eventAuxiliary().run(), ev.eventAuxiliary().luminosityBlock(), ev.eventAuxiliary().event()))!=map.end())return 1;                   
 
-    edm::TriggerResultsByName metFilters = ev.triggerResultsByName("PAT");   //is present only if PAT (and miniAOD) is not run simultaniously with RECO       
-    if(!metFilters.isValid()){metFilters = ev.triggerResultsByName("RECO");} //if not present, then it's part of RECO                                         
-    if(!metFilters.isValid()){                                                                                                                                
-      printf("TriggerResultsByName for MET filters is not found in the process, as a consequence the MET filter is disabled for this event\n");               
+    if(map.find( RuLuEv(ev.eventAuxiliary().run(), ev.eventAuxiliary().luminosityBlock(), ev.eventAuxiliary().event()))!=map.end())return 1;
+
+    edm::TriggerResultsByName metFilters = ev.triggerResultsByName("PAT");   //is present only if PAT (and miniAOD) is not run simultaniously with RECO
+    if(!metFilters.isValid()){metFilters = ev.triggerResultsByName("RECO");} //if not present, then it's part of RECO
+    if(!metFilters.isValid()){
+      printf("TriggerResultsByName for MET filters is not found in the process, as a consequence the MET filter is disabled for this event\n");
     }
 
-    if(!utils::passTriggerPatterns(metFilters, "Flag_globalTightHalo2016Filter")) return 2;                                                                   
-    if(!utils::passTriggerPatterns(metFilters, "Flag_goodVertices"              )) return 3;                                                                  
-    if(!utils::passTriggerPatterns(metFilters, "Flag_eeBadScFilter"         )) return 4;                                                                      
-    if(!utils::passTriggerPatterns(metFilters, "Flag_EcalDeadCellTriggerPrimitiveFilter")) return 5;                                                          
-    if(!utils::passTriggerPatterns(metFilters, "Flag_HBHENoiseFilter"  )) return 6;                                                                           
-    if(!utils::passTriggerPatterns(metFilters, "Flag_HBHENoiseIsoFilter"  )) return 7;          
+    if(!utils::passTriggerPatterns(metFilters, "Flag_globalTightHalo2016Filter")) return 2;
+    if(!utils::passTriggerPatterns(metFilters, "Flag_goodVertices"              )) return 3;
+    if(!utils::passTriggerPatterns(metFilters, "Flag_eeBadScFilter"         )) return 4;
+    if(!utils::passTriggerPatterns(metFilters, "Flag_EcalDeadCellTriggerPrimitiveFilter")) return 5;
+    if(!utils::passTriggerPatterns(metFilters, "Flag_HBHENoiseFilter"  )) return 6;
+    if(!utils::passTriggerPatterns(metFilters, "Flag_HBHENoiseIsoFilter"  )) return 7;
 
     return 0;
-  }    
+  }
 
-  int MetFilter::passMetFilterInt(const fwlite::Event& ev){  
+  int MetFilter::passMetFilterInt(const fwlite::Event& ev){
      if(map.find( RuLuEv(ev.eventAuxiliary().run(), ev.eventAuxiliary().luminosityBlock(), ev.eventAuxiliary().event()))!=map.end())return 1;
 
-    // Legacy: the different collection name was necessary with the early 2015B prompt reco        
+    // Legacy: the different collection name was necessary with the early 2015B prompt reco
 //    edm::TriggerResultsByName metFilters = isPromptReco ? ev.triggerResultsByName("RECO") : ev.triggerResultsByName("PAT");
     edm::TriggerResultsByName metFilters = ev.triggerResultsByName("PAT");   //is present only if PAT (and miniAOD) is not run simultaniously with RECO
     if(!metFilters.isValid()){metFilters = ev.triggerResultsByName("RECO");} //if not present, then it's part of RECO
-    if(!metFilters.isValid()){       
-      printf("TriggerResultsByName for MET filters is not found in the process, as a consequence the MET filter is disabled for this event\n");    
+    if(!metFilters.isValid()){
+      printf("TriggerResultsByName for MET filters is not found in the process, as a consequence the MET filter is disabled for this event\n");
     }
 
 
-    // Documentation:    
+    // Documentation:
     // -------- Full MET filters list (see bin/chhiggs/runAnalysis.cc for details on how to print it out ------------------
     // Flag_trackingFailureFilter
     // Flag_goodVertices                        -------> Recommended by PAG
@@ -1140,7 +1350,7 @@ void MetFilter::FillBadEvents(std::string path){
     // Flag_HBHENoiseFilter                     -------> Recommended by PAG
     // Flag_trkPOG_toomanystripclus53X
     // Flag_hcalLaserEventFilter
- 
+
 
     // Notes (from https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2015#ETmiss_filters ):
     // - For the RunIISpring15DR74 MC campaing, the process name in PAT.
@@ -1150,13 +1360,13 @@ void MetFilter::FillBadEvents(std::string path){
     // - Recommendations on how to use MET filers are given in https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2 . Note in particular that the HBHO noise filter must be re-run from MiniAOD instead of using the flag stored in the TriggerResults; this applies to all datasets (MC, PromptReco, 17Jul2015 re-MiniAOD)
     // -------------------------------------------------
 
-    if(!utils::passTriggerPatterns(metFilters, "Flag_CSCTightHaloFilter"                     )) return 2; 
+    if(!utils::passTriggerPatterns(metFilters, "Flag_CSCTightHaloFilter"                     )) return 2;
     if(!utils::passTriggerPatterns(metFilters, "Flag_goodVertices"                           )) return 3;
     if(!utils::passTriggerPatterns(metFilters, "Flag_eeBadScFilter"                          )) return 4;
     if(!utils::passTriggerPatterns(metFilters, "Flag_EcalDeadCellTriggerPrimitiveFilter"     )) return 5;
     if(!utils::passTriggerPatterns(metFilters, "Flag_HBHENoiseFilter"                        )) return 6;
 
-/*    
+/*
     // HBHE filter needs to be complemented with , because it is messed up in data (see documentation below)
     //if(!utils::passTriggerPatterns(metFilters, "Flag_HBHENoiseFilter"   )) return false; // Needs to be rerun for both data (prompt+reReco) and MC, for now.
     // C++ conversion of the python FWLITE example: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2
@@ -1174,7 +1384,7 @@ void MetFilter::FillBadEvents(std::string path){
 //    bool failCommon(summary.maxHPDHits() >= 17  || summary.maxHPDNoOtherHits() >= 10 || summary.maxZeros() >= 9e9 );
     // IgnoreTS4TS5ifJetInLowBVRegion is always false, skipping.
 //    if((failCommon || summary.HasBadRBXRechitR45Loose() )) return 5;  //for 25ns only
-   
+
      //HBHE ISO NOISE
      if(summary.numIsolatedNoiseChannels() >=10)return 10;
      if(summary.isolatedNoiseSumE() >=50) return 11;
@@ -1192,16 +1402,16 @@ void MetFilter::FillBadEvents(std::string path){
       const reco::Track &tk = *mu.innerTrack();
       return tk.algoMask().count() == 1 && tk.isAlgoInMask(reco::Track::muonSeededStepOutIn);
   }
-  bool preselection(const reco::Muon &mu, bool selectClones_)  { 
+  bool preselection(const reco::Muon &mu, bool selectClones_)  {
       return mu.isGlobalMuon() && (!selectClones_ || outInOnly(mu));
   }
-  bool tighterId(const reco::Muon &mu)  { 
-      return muon::isMediumMuon(mu) && mu.numberOfMatchedStations() >= 2; 
+  bool tighterId(const reco::Muon &mu)  {
+      return muon::isMediumMuon(mu) && mu.numberOfMatchedStations() >= 2;
   }
   bool tightGlobal(const reco::Muon &mu)  {
       return (mu.globalTrack()->hitPattern().muonStationsWithValidHits() >= 3 && mu.globalTrack()->normalizedChi2() <= 20);
   }
-  bool safeId(const reco::Muon &mu)  { 
+  bool safeId(const reco::Muon &mu)  {
       if (mu.muonBestTrack()->ptError() > 0.2 * mu.muonBestTrack()->pt()) { return false; }
       return mu.numberOfMatchedStations() >= 1 || tightGlobal(mu);
   }
@@ -1213,11 +1423,11 @@ void MetFilter::FillBadEvents(std::string path){
 bool MetFilter::BadGlobalMuonTaggerFilter(const fwlite::Event& ev,std::unique_ptr<std::vector<reco::Muon*>> &out1, bool selectClones_){
 
         reco::VertexCollection vtx;
-        fwlite::Handle< reco::VertexCollection > vtxHandle; 
+        fwlite::Handle< reco::VertexCollection > vtxHandle;
         vtxHandle.getByLabel(ev, "offlineSlimmedPrimaryVertices");
-        if(vtxHandle.isValid()){ vtx = *vtxHandle;}	
+        if(vtxHandle.isValid()){ vtx = *vtxHandle;}
 
-	pat::MuonCollection muons; 
+	pat::MuonCollection muons;
 	fwlite::Handle< pat::MuonCollection > muonsHandle;
         muonsHandle.getByLabel(ev, "slimmedMuons");
 	if(muonsHandle.isValid()){ muons = *muonsHandle;}
@@ -1234,7 +1444,7 @@ bool MetFilter::BadGlobalMuonTaggerFilter(const fwlite::Event& ev,std::unique_pt
         if (!mu.isPFMuon() || mu.innerTrack().isNull()) {
             goodMuon.push_back(-1); // bad but we don't care
             continue;
-        } 
+        }
         if (preselection(mu,selectClones_)) {
             float dxypv = std::abs(mu.innerTrack()->dxy(PV));
             float dzpv  = std::abs(mu.innerTrack()->dz(PV));
@@ -1268,7 +1478,7 @@ bool MetFilter::BadGlobalMuonTaggerFilter(const fwlite::Event& ev,std::unique_pt
                     if (verbose_) printf("     tagged as clone of muon %d of pt %.1f eta %+.3f phi %+.3f\n", int(j+1), muons[j].pt(), muons[j].eta(), muons[j].phi());
                     bad = true;
                     break;
-                } 
+                }
             }
         }
         if (bad) {
@@ -1306,12 +1516,12 @@ std::pair<double, double> scaleVariation(const fwlite::Event& ev){
                         	if( lheEPHandle->weights()[i].id != "1001" || lheEPHandle->weights()[i].id != "1006" || lheEPHandle->weights()[i].id != "1008" ){
                                 	double local_weight = 0;
                                 	local_weight = ( lheEPHandle->weights()[i].wgt / lheEPHandle->originalXWGTUP() );
-					//std::cout << "Local weight: " << local_weight << std::endl; 
+					//std::cout << "Local weight: " << local_weight << std::endl;
                                 	scaleUp = std::max(scaleUp, local_weight);
                                 	scaleDw = std::min(scaleDw, local_weight);
                         	}
                  	}
-			
+
 		 } else { scaleUp = 1.;  scaleDw = 1.;}
          }
 	 //std::cout << "ScaleUp Value: " << scaleUp << "; ScaleDwn Value: " << scaleDw << std::endl;
@@ -1343,13 +1553,13 @@ double pdfVariation(const fwlite::Event& ev){
                 if( check_in ){
                 	for (unsigned int i=0; i<lheEPHandle->weights().size(); i++) {
                         	std::string::size_type sz;
-                        	double id = std::stod( lheEPHandle->weights()[i].id, &sz); 
-                                if( id<2001 || id>2100 ) continue;	
+                        	double id = std::stod( lheEPHandle->weights()[i].id, &sz);
+                                if( id<2001 || id>2100 ) continue;
 				//std::cout << "Weight: " << lheEPHandle->weights()[i].wgt << "; Nominal Weight: " << lheEPHandle->originalXWGTUP() << std::endl;
                                 sum += std::pow( (lheEPHandle->weights()[i].wgt / lheEPHandle->originalXWGTUP() - 1 ), 2);
-                                N++; 
-                                	
-                        }	
+                                N++;
+
+                        }
 			pdfVar = 1+ std::sqrt( sum/ ( N -1 ) ); //+1 variation
         	} else { pdfVar = 1.; }
 	}
@@ -1369,7 +1579,7 @@ double alphaVariation(const fwlite::Event& ev){
         if( lheEPHandle.isValid() ){
                 for (unsigned int i=0; i<lheEPHandle->weights().size(); i++) {
                         std::string::size_type sz;
-                        double id = std::stod( lheEPHandle->weights()[i].id, &sz);		
+                        double id = std::stod( lheEPHandle->weights()[i].id, &sz);
 			idVect.push_back( id );
 		}
 		itone = find( idVect.begin(), idVect.end(), 2101);
@@ -1377,7 +1587,7 @@ double alphaVariation(const fwlite::Event& ev){
 		if( itone != idVect.end() && ittwo != idVect.end() ){
 			for (unsigned int i=0; i<lheEPHandle->weights().size(); i++) {
                         	std::string::size_type sz;
-                        	double id = std::stod( lheEPHandle->weights()[i].id, &sz);	
+                        	double id = std::stod( lheEPHandle->weights()[i].id, &sz);
                         	if( ( id == 2101 ) ){
                                 	local_alpha_one = ( lheEPHandle->weights()[i].wgt / lheEPHandle->originalXWGTUP() );
                         	} else if( ( id == 2102 ) ){
@@ -1391,17 +1601,17 @@ double alphaVariation(const fwlite::Event& ev){
 	//std::cout << "Alpha Uncertainties: " << alphaVar << std::endl;
         return alphaVar;
 }
-  
-                                                                                                                                              
+
+
   double getHTScaleFactor(TString dtag, double lheHt)
   {
     // NNLO per-event weights as a function of generator level HT
     // (from https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsToTauTauWorking2015#MC_and_data_samples )
-    // For DY-5to50, only LO is available.   
+    // For DY-5to50, only LO is available.
 
     // Please look below for the code snippet necessary to run this.
 
-    double htScaleFactor(1.0);              
+    double htScaleFactor(1.0);
     if(dtag.Contains("WJetsToLNu"))
       {
         // NNLO
@@ -1413,13 +1623,13 @@ double alphaVariation(const fwlite::Event& ev){
         // /WJetsToLNu_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8         18.77
         if     (lheHt<100              ) htScaleFactor=0.8520862372;
         else if(lheHt>=100 && lheHt<200) htScaleFactor=0.1352710705;
-        else if(lheHt>=200 && lheHt<400) htScaleFactor=0.076142149 ;                                                
+        else if(lheHt>=200 && lheHt<400) htScaleFactor=0.076142149 ;
         else if(lheHt>=400 && lheHt<600) htScaleFactor=0.0326980819;
         else if(lheHt>=600             ) htScaleFactor=0.0213743732;
-      }                                     
+      }
     else if(dtag.Contains("DYJetsToLL_M-50"))
-      {                                     
-        // NNLO                             
+      {
+        // NNLO
         // Valid for:                                                               xsection [pb]
         // /DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8                    4895
         // /DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8         139.4
@@ -1431,10 +1641,10 @@ double alphaVariation(const fwlite::Event& ev){
         else if(lheHt>=200 && lheHt<400) htScaleFactor=0.049972089 ;
         else if(lheHt>=400 && lheHt<600) htScaleFactor=0.0062770613;
         else if(lheHt>=600             ) htScaleFactor=0.00271213  ;
-      }                                     
+      }
     else if(dtag.Contains("DYJetsToLL_M-5to50"))
       {
-        // LO                               
+        // LO
         // Valid for:                                                               xsection [pb]
         // /DYJetsToLL_M-5to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8                  71310
         // /DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8        224.2
@@ -1446,28 +1656,28 @@ double alphaVariation(const fwlite::Event& ev){
         else if(lheHt>=200 && lheHt<400) htScaleFactor=0.0365903335;
         else if(lheHt>=400 && lheHt<600) htScaleFactor=0.0035837837;
         else if(lheHt>=600             ) htScaleFactor=0.0011156801;
-      }                                     
+      }
 
     htScaleFactor /= 1000; // The scale factors are derived for 1/fb, whereas we normalize in picobarns
-    return htScaleFactor;                   
+    return htScaleFactor;
 
     // In order to use this stitching, you need to run a full set of HT-binned samples plus the inclusive one.
     // You should *NOT* have the nhepup cut that was used for the stitching of jet-binned samples. Either one or the other.
-    
+
     // HT-binned samples stitching: https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsToTauTauWorking2015#MC_and_data_samples
     /*
     double weightGen(1.0);
     // do not correct for negative weights: these are LO samples
-      
+
     bool isV0JetsMC   (isMC && (dtag.Contains ("DYJetsToLL") || dtag.Contains ("WJets")));
     if(isV0JetsMC)
       {
-        // access generator level HT               
+        // access generator level HT
         fwlite::Handle<LHEEventProduct> lheEventProduct;
         lheEventProduct.getByLabel(ev, "externalLHEProducer");
         //edm::Handle<LHEEventProduct> lheEventProduct;
         //ev.getByLabel( 'externalLHEProducer', lheEventProduct);
-        const lhef::HEPEUP& lheEvent = lheEventProduct->hepeup(); 
+        const lhef::HEPEUP& lheEvent = lheEventProduct->hepeup();
         std::vector<lhef::HEPEUP::FiveVector> lheParticles = lheEvent.PUP;
         double lheHt = 0.;
         size_t numParticles = lheParticles.size();
@@ -1476,14 +1686,14 @@ double alphaVariation(const fwlite::Event& ev){
           int status = lheEvent.ISTUP[idxParticle];
           if ( status == 1 && ((absPdgId >= 1 && absPdgId <= 6) || absPdgId == 21) ) { // quarks and gluons
             lheHt += TMath::Sqrt(TMath::Power(lheParticles[idxParticle][0], 2.) + TMath::Power(lheParticles[idxParticle][1], 2.)); // first entry is px, second py
-          }                                        
+          }
         }
         if(debug) cout << "Sample: " << dtag << ", lheHt: " << lheHt << ", scale factor from spreadsheet: " << patUtils::getHTScaleFactor(dtag, lheHt) << endl;
         weightGen *=   patUtils::getHTScaleFactor(dtag, lheHt);
-      }         
+      }
 
       weight *= weightGen;
     */
-  }                                               
+  }
 
 }


### PR DESCRIPTION
Here the PR, 
Apologize for the non really clean PR, there are some debug lines that I will remove in the futur.
Also I duplicate the passIso for muon to be sure that the isolation behaviour will be identical in the other part of the code which are calling the passIso function. 

I checked on DY the new ID and I see almost identical distributions (see for example the z mass in attachment). A test on ggH3000 is running (but they are a lot of debug lines which make the test slow in interactive).
*before PR=*
<img width="530" alt="beforepr" src="https://cloud.githubusercontent.com/assets/3070676/23093414/c8e5bbd4-f5e2-11e6-90b7-bb1c0bbf6a17.png">
*after PR=*
<img width="508" alt="afterpr" src="https://cloud.githubusercontent.com/assets/3070676/23093415/c8ffb2dc-f5e2-11e6-8b49-085f504c35ce.png">