### PR TITLE
debug for slewrate correction

### DIFF
--- a/interface/MacroUtils.h
+++ b/interface/MacroUtils.h
@@ -154,7 +154,9 @@ namespace utils
 //    
 //    //set new jet energy corrections
      void updateJEC(pat::JetCollection& jets, FactorizedJetCorrector *jesCor, JetCorrectionUncertainty *totalJESUnc, float rho, int nvtx,bool isMC);
-    
+
+     void SlewRateCorrection(const fwlite::Event& ev, pat::Electron& ele);   
+ 
 //    //apply MET variations
 //    enum METvariations { NOMINAL, JERUP, JERDOWN, JESUP, JESDOWN, UMETUP, UMETDOWN, LESUP, LESDOWN };
 //    std::vector<LorentzVector> getMETvariations(LorentzVector &rawMETP4, pat::JetCollection &jets, std::vector<patUtils::GenericLepton> &leptons, bool isMC);


### PR DESCRIPTION
Hi 

I forget to add Slew rate function deceleration in MacroUtils.h file.
Not it is added, it must compiles now.
I have checked too.

