### PR TITLE
added separate json with re-miniAOD data

### DIFF
--- a/test/hzz2l2v/samples_re-miniAOD_full2016_GGH.json
+++ b/test/hzz2l2v/samples_re-miniAOD_full2016_GGH.json
@@ -1,0 +1,3388 @@
+{
+    "proc": [
+        {
+            "color": 1,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016B-03Feb2017_ver1-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_MuEG2016B_ver1",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		 {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016B-03Feb2017_ver2-v2/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_MuEG2016B_ver2",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016C-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_MuEG2016C",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016D-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_MuEG2016D",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016E-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_MuEG2016E",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016F-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_MuEG2016F",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016G-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_MuEG2016G",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016H-03Feb2017_ver2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_MuEG2016H_ver2",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016H-03Feb2017_ver3-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_MuEG2016H_ver3",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016B-03Feb2017_ver1-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleElectron2016B_ver1",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		 {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016B-03Feb2017_ver2-v2/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleElectron2016B_ver2",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016C-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleElectron2016C",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016D-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleElectron2016D",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016E-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleElectron2016E",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016F-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleElectron2016F",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016G-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleElectron2016G",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016H-03Feb2017_ver2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleElectron2016H_ver2",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_03Feb2017ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016H-03Feb2017_ver3-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleElectron2016H_ver3",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016B-03Feb2017_ver1-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleMuon2016B_ver1",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		 {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016B-03Feb2017_ver2-v2/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleMuon2016B_ver2",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016C-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleMuon2016C",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016D-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleMuon2016D",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016E-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleMuon2016E",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016F-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleMuon2016F",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016G-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleMuon2016G",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016H-03Feb2017_ver2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleMuon2016H_ver2",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_03Feb2017ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016H-03Feb2017_ver3-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SingleMuon2016H_ver3",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016B-03Feb2017_ver1-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleMuon2016B_ver1",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		 {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016B-03Feb2017_ver2-v2/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleMuon2016B_ver2",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016C-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleMuon2016C",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016D-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleMuon2016D",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016E-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleMuon2016E",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016F-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleMuon2016F",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016G-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleMuon2016G",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016H-03Feb2017_ver2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleMuon2016H_ver2",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_03Feb2017ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016H-03Feb2017_ver3-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleMuon2016H_ver3",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016B-03Feb2017_ver1-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleEG2016B_ver1",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		 {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016B-03Feb2017_ver2-v2/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleEG2016B_ver2",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016C-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleEG2016C",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016D-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleEG2016D",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016E-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleEG2016E",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016F-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleEG2016F",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016G-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleEG2016G",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016H-03Feb2017_ver2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleEG2016H_ver2",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_03Feb2017ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016H-03Feb2017_ver3-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_DoubleEG2016H_ver3",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                }	
+            ],
+            "fill": 0,
+            "isdata": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "marker": 20,
+            "msize": 0.7,
+            "tag": "data"
+        },
+        {
+            "color": 595,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZZ2l2q_2016",
+                    "xsec": 3.22
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZZ2l2nu_2016",
+                    "xsec": 0.564
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_photoncontrol",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "mctruthmode": 15,
+            "tag": "ZZ#rightarrow Z#tau#tau"
+        },
+        {
+            "color": 592,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZZ2l2q_2016",
+                    "xsec": 3.22
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZZ2l2nu_2016",
+                    "xsec": 0.564
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_photoncontrol",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "mctruthmode": 1113,
+            "tag": "ZZ"
+        },
+        {
+            "2l2v_photonsOnly": {
+                "suffix": "reweighted"
+            },
+            "color": 590,
+            "data": [
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/WWTo2L2Nu_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WW2l2nu_2016",
+                    "xsec": 12.178
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WWlnu2q_2016",
+                    "xsec": 49.997
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WWlnu2q_ext1_2016",
+                    "xsec": 49.997
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_photoncontrol",
+                "2l2v_photonsOnly",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "tag": "WW"
+        },
+        {
+            "2l2v_photonsOnly": {
+                "suffix": "reweighted"
+            },
+            "color": 594,
+            "data": [
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WZ3lnu_2016",
+                    "xsec": 4.42965
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WZ2l2q_2016",
+                    "xsec": 5.595
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_photoncontrol",
+                "2l2v_photonsOnly",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "tag": "WZ"
+        },
+        {
+            "color": 869,
+            "data": [
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/ZZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZZZ_2016",
+                    "xsec": 0.01398
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WZZ_2016",
+                    "xsec": 0.05565
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WWZ_2016",
+                    "xsec": 0.1651
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_photoncontrol",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "tag": "ZVV"
+        },
+        {
+            "2l2v_photonsOnly": {
+                "suffix": "reweighted"
+            },
+            "color": 8,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+       		        "/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_TT2l2nu_ext1_2016",
+                    "xsec": 87.31
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_SingleT_s_2016",
+                    "xsec": 3.362
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_SingleT_t_2016_old",
+                    "xsec": 70.69
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_SingleT_atW_2016",
+                    "xsec": 35.6
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_SingleT_tW_2016",
+                    "xsec": 35.6
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_TTWJetslnu_2016",
+                    "xsec": 0.2043
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_TTZJets2l2nu_2016",
+                    "xsec": 0.2529
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_photoncontrol",
+                "2l2v_photonsOnly",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "tag": "Top"
+        },
+        {
+            "2l2v_photonsOnly": {
+                "suffix": "reweighted"
+            },
+            "color": 623,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WJets_2016",
+                    "xsec": 61526.7
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WJets_HT-100To200_ext1_2016",
+                    "xsec": 1345
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WJets_HT-200To400_2016",
+                    "xsec": 359.7
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WJets_HT-200To400_ext1_2016",
+                    "xsec": 359.7
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WJets_HT-400To600_2016",
+                    "xsec": 48.91
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WJets_HT-400To600_ext1_2016",
+                    "xsec": 48.91
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_HT-600To800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WJets_HT-600To800_2016",
+                    "xsec": 12.05
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_HT-600To800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WJets_HT-600To800_ext1_2016",
+                    "xsec": 12.05
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_HT-800To1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WJets_HT-800To1200_2016",
+                    "xsec": 5.501
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_HT-800To1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WJets_HT-800To1200_ext1_2016",
+                    "xsec": 5.501
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_HT-1200To2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WJets_HT-1200To2500_2016",
+                    "xsec": 1.329
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_HT-1200To2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WJets_HT-1200To2500_ext1_2016",
+                    "xsec": 1.329
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_HT-2500ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WJets_HT-2500ToInf_2016",
+                    "xsec": 0.03216
+                }
+						],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_mcbased_SM",
+                "2l2v_datadriven",
+                "2l2v_datadriven_SM",
+                "2l2v_photoncontrol",
+                "2l2v_photonsOnly"
+            ],
+            "tag": "W#rightarrow l#nu"
+        },
+        {
+            "2l2v_photonsOnly": {
+                "suffix": "reweighted"
+            },
+            "color": 833,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
+                    "xsec": 18610
+                },
+     		{
+		"br": [ 1.0 ],
+		"dset": [
+		   "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+		],
+		"dtag":  "MC13TeV_DYJetsToLL_50toInf_2016",
+		"xsec": 5765.4 
+		}
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_photoncontrol",
+                "2l2v_photonsOnly",
+                "2l2v_mcbased_SM",
+                "2l2v_datadriven",
+                "2l2v_datadriven_SM"
+            ],
+            "mctruthmode": 15,
+            "tag": "Z#rightarrow #tau#tau"
+        },
+        {
+            "color": 834,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_5to50_HT-100To200_2016",
+                    "xsec": 224.2
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_5to50_HT-200To400_2016",
+                    "xsec": 37.2
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_5to50_HT-200To400_ext1_2016",
+                    "xsec": 37.2
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_5to50_HT-400To600_2016",
+                    "xsec": 3.581
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_5to50_HT-400To600_ext1_2016",
+                    "xsec": 3.581
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_5to50_HT-600ToInf_2016",
+                    "xsec": 1.124
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_5to50_HT-600ToInf_ext1_2016",
+                    "xsec": 1.124
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-100To200_2016",
+                    "xsec": 147.4
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-100To200_ext1_2016",
+                    "xsec": 147.4
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-200To400_2016",
+                    "xsec": 40.99
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-200To400_ext1_2016",
+                    "xsec": 40.99
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-400To600_2016",
+                    "xsec": 5.678
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-400To600_ext1_2016",
+                    "xsec": 5.678
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-600to800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-600To800_2016",
+                    "xsec": 1.367
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-800to1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-800To1200_2016",
+                    "xsec": 0.6304
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-1200to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-1200To2500_2016",
+                    "xsec": 0.1514
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-2500toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-2500ToInf_2016",
+                    "xsec": 0.003565
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016"
+            ],
+            "mctruthmode": 15,
+            "tag": "Z#rightarrow #tau#tau, HT>100"
+        },
+        {
+            "2l2v_photonsOnly": {
+                "suffix": "reweighted"
+            },
+            "color": 831,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
+                    "xsec": 18610
+                },
+             	{
+		"br": [ 1.0 ],
+		"dset": [
+		   "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+		],
+		"dtag":  "MC13TeV_DYJetsToLL_50toInf_2016",
+		"xsec": 5765.4 
+		}
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_photoncontrol",
+                "2l2v_photonsOnly",
+                "2l2v_mcbased_SM",
+                "2l2v_photonZ"
+            ],
+            "mctruthmode": 1113,
+            "tag": "Z#rightarrow ee/#mu#mu"
+        },
+        {
+            "color": 832,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_5to50_HT-100To200_2016",
+                    "xsec": 224.2
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_5to50_HT-200To400_2016",
+                    "xsec": 37.2
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_5to50_HT-200To400_ext1_2016",
+                    "xsec": 37.2
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_5to50_HT-400To600_2016",
+                    "xsec": 3.581
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_5to50_HT-400To600_ext1_2016",
+                    "xsec": 3.581
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_5to50_HT-600ToInf_2016",
+                    "xsec": 1.124
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_5to50_HT-600ToInf_ext1_2016",
+                    "xsec": 1.124
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-100To200_2016",
+                    "xsec": 147.4
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-100To200_ext1_2016",
+                    "xsec": 147.4
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-200To400_2016",
+                    "xsec": 40.99
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-200To400_ext1_2016",
+                    "xsec": 40.99
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-400To600_2016",
+                    "xsec": 5.678
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-400To600_ext1_2016",
+                    "xsec": 5.678
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-600to800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-600To800_2016",
+                    "xsec": 1.367
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-800to1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-800To1200_2016",
+                    "xsec": 0.6304
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-1200to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-1200To2500_2016",
+                    "xsec": 0.1514
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_HT-2500toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_HT-2500ToInf_2016",
+                    "xsec": 0.003565
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016"
+            ],
+            "mctruthmode": 1113,
+            "tag": "Z#rightarrow ee/#mu#mu, HT>100"
+        },
+        {
+            "2l2v_photonsOnly": {
+                "suffix": "reweighted"
+            },
+            "color": 7,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZJetsToNuNu_HT-100To200_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZJetsToNuNu_HT-100To200_2016",
+                    "xsec": 280.35
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZJetsToNuNu_HT-200To400_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZJetsToNuNu_HT-200To400_2016",
+                    "xsec": 77.67
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZJetsToNuNu_HT-400To600_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZJetsToNuNu_HT-400To600_2016",
+                    "xsec": 10.73
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZJetsToNuNu_HT-600To800_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZJetsToNuNu_HT-600To800_2016",
+                    "xsec": 3.221
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZJetsToNuNu_HT-800To1200_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZJetsToNuNu_HT-800To1200_2016",
+                    "xsec": 1.474
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/ZJetsToNuNu_HT-1200To2500_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZJetsToNuNu_HT-1200To2500_2016",
+                    "xsec": 0.3586
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/ZJetsToNuNu_HT-1200To2500_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZJetsToNuNu_HT-1200To2500_ext1_2016",
+                    "xsec": 0.3586
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZJetsToNuNu_HT-2500ToInf_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZJetsToNuNu_HT-2500ToInf_2016",
+                    "xsec": 0.008203
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_photoncontrol",
+                "2l2v_photonsOnly"
+            ],
+            "tag": "Z#rightarrow #nu#nu"
+        },
+        {
+            "2l2v_photonsOnly": {
+                "suffix": "reweighted"
+            },
+            "color": 693,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_TTGJets_2016",
+                    "xsec": 3.697
+                },
+                {
+                    "br": [
+                        0.25
+                    ],
+                    "dset": [
+                        "/TGJets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_TGJets_2016",
+                    "xsec": 2.967
+                },
+                {
+                    "br": [
+                        0.75
+                    ],
+                    "dset": [
+                        "/TGJets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_TGJets_ext1_2016",
+                    "xsec": 2.967
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_photoncontrol",
+                "2l2v_photonsOnly"
+            ],
+            "tag": "Top+#gamma"
+        },
+        {
+            "2l2v_photonsOnly": {
+                "suffix": "reweighted"
+            },
+            "color": 635,
+            "data": [
+                {
+                    "br": [
+                        0.25
+                    ],
+                    "dset": [
+                        "/ZGTo2LG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZGToLNuGi_2016",
+                    "xsec": 117.864
+                },
+                {
+                    "br": [
+                        0.75
+                    ],
+                    "dset": [
+                        "/ZGTo2LG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZGToLNuGi_ext1_2016",
+                    "xsec": 117.864
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_photoncontrol",
+                "2l2v_photonsOnly"
+            ],
+            "tag": "Z#gamma #rightarrow ll#gamma"
+        },
+        {
+            "2l2v_photonsOnly": {
+                "suffix": "reweighted"
+            },
+            "color": 800,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZNuNuGJets_MonoPhoton_PtG-40to130_TuneCUETP8M1_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZNuNuGJets_PtG-40to130_2016",
+                    "xsec": 2.816
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZNuNuGJets_MonoPhoton_PtG-130_TuneCUETP8M1_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_ZNuNuGJets_PtG-130_2016",
+                    "xsec": 0.223
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_photoncontrol",
+                "2l2v_photonsOnly"
+            ],
+            "tag": "Z#gamma #rightarrow #nu#nu#gamma"
+        },
+        {
+            "2l2v_photonsOnly": {
+                "suffix": "reweighted"
+            },
+            "color": 52,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/WGToLNuG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WGToLNuG_2016",
+                    "xsec": 489
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_photoncontrol",
+                "2l2v_photonsOnly"
+            ],
+            "tag": "W#gamma #rightarrow l#nu#gamma"
+        },
+        {
+            "color": 21,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_HT100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_HT100to200_2016",
+                    "xsec": 27990000
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_HT200to300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_HT200to300_2016",
+                    "xsec": 1712000
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/QCD_HT300to500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_HT300to500_2016",
+                    "xsec": 347700
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/QCD_HT300to500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_HT300to500_ext1_2016",
+                    "xsec": 347700
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_HT500to700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_HT500to700_2016",
+                    "xsec": 32100
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/QCD_HT700to1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_HT700to1000_2016",
+                    "xsec": 6831
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/QCD_HT700to1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_HT700to1000_ext1_2016",
+                    "xsec": 6831
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/QCD_HT1000to1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_HT1000to1500_2016",
+                    "xsec": 1207
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/QCD_HT1000to1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_HT1000to1500_ext1_2016",
+                    "xsec": 1207
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/QCD_HT1500to2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_HT1500to2000_2016",
+                    "xsec": 119.9
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/QCD_HT1500to2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_HT1500to2000_ext1_2016",
+                    "xsec": 119.9
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/QCD_HT2000toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_HT2000toInf_2016",
+                    "xsec": 25.24
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/QCD_HT2000toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_HT2000toInf_ext1_2016",
+                    "xsec": 25.24
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_photoncontrol"
+            ],
+            "tag": "QCD, HT>100"
+        },
+        {
+            "color": 24,
+            "data": [
+                {
+                    "br": [
+                        0.0096
+                    ],
+                    "dset": [
+                        "/QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_Pt20To30_EMEnr_2016",
+                    "xsec": 557600000
+                },
+                {
+                    "br": [
+                        0.0365
+                    ],
+                    "dset": [
+                        "/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_Pt30To50_EMEnr_2016",
+                    "xsec": 136000000
+                },
+                {
+                    "br": [
+                        0.0365
+                    ],
+                    "dset": [
+                        "/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_Pt30To50_EMEnr_ext1_2016",
+                    "xsec": 136000000
+                },
+                {
+                    "br": [
+                        0.146
+                    ],
+                    "dset": [
+                        "/QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_Pt50To80_EMEnr_2016",
+                    "xsec": 19800000
+                },
+                {
+                    "br": [
+                        0.125
+                    ],
+                    "dset": [
+                        "/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_Pt80To120_EMEnr_2016",
+                    "xsec": 2800000
+                },
+                {
+                    "br": [
+                        0.132
+                    ],
+                    "dset": [
+                        "/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_Pt120To170_EMEnr_2016",
+                    "xsec": 477000
+                },
+                {
+                    "br": [
+                        0.165
+                    ],
+                    "dset": [
+                        "/QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_Pt170To300_EMEnr_2016",
+                    "xsec": 114000
+                },
+                {
+                    "br": [
+                        0.15
+                    ],
+                    "dset": [
+                        "/QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_Pt300ToInf_EMEnr_2016",
+                    "xsec": 9000
+                },
+                {
+                    "br": [
+                        0.00042
+                    ],
+                    "dset": [
+                        "/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_QCD_Pt20ToInf_MuEnr_2016",
+                    "xsec": 720648000
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_photoncontrol"
+            ],
+            "tag": "QCD_EMEnr"
+        },
+        {
+            "2l2v_mcphotonsOnly": {
+                "suffix": "reweighted"
+            },
+            "color": 390,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GJets_HT-40To100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GJet_HT-40to100_2016",
+                    "xsec": 20730.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GJets_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GJet_HT-100to200_2016",
+                    "xsec": 9226.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GJets_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GJet_HT-200to400_2016",
+                    "xsec": 2300.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GJets_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GJet_HT-400to600_2016",
+                    "xsec": 277.4
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GJet_HT-600toInf_2016",
+                    "xsec": 93.38
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_photoncontrol",
+                "2l2v_mcphotonsOnly",
+                "2l2v_photonZ"
+            ],
+            "tag": "#gamma+jets"
+        },
+        {
+            "2l2v_photonsOnly": {
+                "suffix": "reweighted"
+            },
+            "color": 1,
+            "data": [
+		{
+                    "br": [
+			1.0
+                    ],
+                    "dset": [
+			"/SinglePhoton/Run2016B-03Feb2017_ver1-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SinglePhoton2016B_ver1",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SinglePhoton/Run2016B-03Feb2017_ver2-v2/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SinglePhoton2016B_ver2",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SinglePhoton/Run2016C-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SinglePhoton2016C",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SinglePhoton/Run2016D-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SinglePhoton2016D",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SinglePhoton/Run2016E-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SinglePhoton2016E",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SinglePhoton/Run2016F-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SinglePhoton2016F",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SinglePhoton/Run2016G-03Feb2017-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SinglePhoton2016G",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SinglePhoton/Run2016H-03Feb2017_ver2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SinglePhoton2016H_ver2",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_03Feb2017ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SinglePhoton/Run2016H-03Feb2017_ver3-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_SinglePhoton2016H_ver3",
+                    "lumiMask": "$CMSSW_BASE/src/UserCode/llvv_fwk/data/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_photoncontrol",
+                "2l2v_photonsOnly",
+                "genuineMet"
+            ],
+            "marker": 20,
+            "msize": 0.7,
+            "tag": "#gamma data"
+        },
+        {
+           "tag":"Top/W/WW",
+           "keys":["2l2v_2016", "2l2v_datadrivenplot"],
+           "isdata":false,
+           "isdatadriven":true,
+           "color":8,
+           "syst":[0.21],
+           "nosample":true,
+           "NRB":[{"tag":"data", "scale":1.0}]
+         }, 
+         {
+           "tag":"Genuine (ewk) MET inv",
+           "keys":["2l2v_2016", "genuineMet"],
+           "isinvisible":true,      
+           "isdata":false,
+           "color":41,
+     	"mixing":[{"tag":"W#gamma #rightarrow l#nu#gamma_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow ll#gamma_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #nu#nu_reweighted", "scale":1.0}, {"tag":"W#rightarrow l#nu_reweighted", "scale":1.0}, {"tag":"Top_reweighted", "scale":1.0},  {"tag":"WZ_reweighted", "scale":1.0},  {"tag":"WW_reweighted", "scale":1.0}, {"tag":"Z#rightarrow #tau#tau_filt15_reweighted", "scale":1.0}, {"tag":"Z#gamma #rightarrow #nu#nu#gamma_reweighted", "scale":1.0}, {"tag":"Top+#gamma_reweighted", "scale":1.0}, {"tag":"Z#rightarrow ee-#mu#mu_filt1113_reweighted", "scale":1.0} ]
+         },
+         {
+           "tag":"Genuine (ewk) MET",
+           "keys":["2l2v_2016", "genuineMet"],
+           "isdata":false,
+           "color":41,
+           "mixing":[{"tag":"Genuine (ewk) MET inv", "scale":1.0}]
+         },
+         {
+           "tag":"Instr. MET",
+           "keys":["2l2v_2016", "genuineMet", "2l2v_datadriven", "2l2v_datadrivenplot", "2l2v_datadriven_SM"],
+           "isdata":false,
+           "isdatadriven":true,
+           "color":831,
+           "syst":[0.25],
+           "mixing":[{"tag":"#gamma data_reweighted", "scale":1.0}, {"tag":"Genuine (ewk) MET inv", "scale":-1.0} ]
+         },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M200_13TeV_powheg2_JHUgenV6_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH200toZZto2L2Nu_SOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 200,
+            "spimpose": true,
+            "tag": "ggH(200)_SOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M200_13TeV_powheg2_JHUgenV6_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH200toZZto2L2Nu_BOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 200,
+            "spimpose": true,
+            "tag": "ggH(200)_BOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M200_13TeV_powheg2_JHUgenV6_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH200toZZto2L2Nu_SandBandInterf_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 200,
+            "spimpose": true,
+            "tag": "ggH(200)_SandBandInterf"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M300_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH300toZZto2L2Nu_SOnly_MELA_powheg_2016",
+                    "split": 14,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_SM_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_SM_MELA",
+                "2l2v_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 300,
+            "spimpose": true,
+            "tag": "ggH(300)_SOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M300_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH300toZZto2L2Nu_BOnly_MELA_powheg_2016",
+                    "split": 14,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_SM_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_SM_MELA",
+                "2l2v_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 300,
+            "spimpose": true,
+            "tag": "ggH(300)_BOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M300_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH300toZZto2L2Nu_SandBandInterf_MELA_powheg_2016",
+                    "split": 14,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_SM_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_SM_MELA",
+                "2l2v_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 300,
+            "spimpose": true,
+            "tag": "ggH(300)_SandBandInterf"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M400_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH400toZZto2L2Nu_SOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 400,
+            "spimpose": true,
+            "tag": "ggH(400)_SOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M400_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH400toZZto2L2Nu_BOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 400,
+            "spimpose": true,
+            "tag": "ggH(400)_BOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M400_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH400toZZto2L2Nu_SandBandInterf_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 400,
+            "spimpose": true,
+            "tag": "ggH(400)_SandBandInterf"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M500_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH500toZZto2L2Nu_SOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 500,
+            "spimpose": true,
+            "tag": "ggH(500)_SOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M500_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH500toZZto2L2Nu_BOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 500,
+            "spimpose": true,
+            "tag": "ggH(500)_BOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M500_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH500toZZto2L2Nu_SandBandInterf_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 500,
+            "spimpose": true,
+            "tag": "ggH(500)_SandBandInterf"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M600_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH600toZZto2L2Nu_SOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 907,
+            "lwidth": 2,
+            "resonance": 600,
+            "spimpose": true,
+            "tag": "ggH(600)_SOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M600_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH600toZZto2L2Nu_BOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 907,
+            "lwidth": 2,
+            "resonance": 600,
+            "spimpose": true,
+            "tag": "ggH(600)_BOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M600_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH600toZZto2L2Nu_SandBandInterf_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 907,
+            "lwidth": 2,
+            "resonance": 600,
+            "spimpose": true,
+            "tag": "ggH(600)_SandBandInterf"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M700_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH700toZZto2L2Nu_SOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 700,
+            "spimpose": true,
+            "tag": "ggH(700)_SOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M700_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH700toZZto2L2Nu_BOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 700,
+            "spimpose": true,
+            "tag": "ggH(700)_BOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M700_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH700toZZto2L2Nu_SandBandInterf_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 700,
+            "spimpose": true,
+            "tag": "ggH(700)_SandBandInterf"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M800_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH800toZZto2L2Nu_SOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 800,
+            "spimpose": true,
+            "tag": "ggH(800)_SOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M800_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH800toZZto2L2Nu_BOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 800,
+            "spimpose": true,
+            "tag": "ggH(800)_BOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M800_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH800toZZto2L2Nu_SandBandInterf_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 800,
+            "spimpose": true,
+            "tag": "ggH(800)_SandBandInterf"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M900_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH900toZZto2L2Nu_SOnly_MELA_powheg_2016",
+                    "split": 16,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_SM_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_SM_MELA",
+                "2l2v_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 900,
+            "spimpose": true,
+            "tag": "ggH(900)_SOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M900_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH900toZZto2L2Nu_BOnly_MELA_powheg_2016",
+                    "split": 16,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_SM_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_SM_MELA",
+                "2l2v_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 900,
+            "spimpose": true,
+            "tag": "ggH(900)_BOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M900_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH900toZZto2L2Nu_SandBandInterf_MELA_powheg_2016",
+                    "split": 13,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_SM_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_SM_MELA",
+                "2l2v_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 900,
+            "spimpose": true,
+            "tag": "ggH(900)_SandBandInterf"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M1000_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH1000toZZto2L2Nu_SOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 1000,
+            "spimpose": true,
+            "tag": "ggH(1000)_SOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M1000_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH1000toZZto2L2Nu_BOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible":true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 1000,
+            "spimpose": true,
+            "tag": "ggH(1000)_BOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M1000_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH1000toZZto2L2Nu_SandBandInterf_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 1000,
+            "spimpose": true,
+            "tag": "ggH(1000)_SandBandInterf"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M1500_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH1500toZZto2L2Nu_SOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 1500,
+            "spimpose": true,
+            "tag": "ggH(1500)_SOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M1500_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH1500toZZto2L2Nu_BOnly_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 1500,
+            "spimpose": true,
+            "tag": "ggH(1500)_BOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M1500_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH1500toZZto2L2Nu_SandBandInterf_MELA_powheg_2016",
+                    "split": 20,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot",
+                "2l2v_datadriven_SM",
+                "2l2v_mcbased_SM"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 1500,
+            "spimpose": true,
+            "tag": "ggH(1500)_SandBandInterf"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M2000_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH2000toZZto2L2Nu_SOnly_MELA_powheg_2016",
+                    "split": 16,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot_SM",
+                "2l2v_datadrivenplot_MELA",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 2000,
+            "spimpose": true,
+            "tag": "ggH(2000)_SOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M2000_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH2000toZZto2L2Nu_BOnly_MELA_powheg_2016",
+                    "split": 16,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot_SM",
+                "2l2v_datadrivenplot_MELA",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 2000,
+            "spimpose": true,
+            "tag": "ggH(2000)_BOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M2000_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH2000toZZto2L2Nu_SandBandInterf_MELA_powheg_2016",
+                    "split": 16,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot_SM",
+                "2l2v_datadrivenplot_MELA",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 2000,
+            "spimpose": true,
+            "tag": "ggH(2000)_SandBandInterf"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M2500_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH2500toZZto2L2Nu_SOnly_MELA_powheg_2016",
+                    "split": 16,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot_SM",
+                "2l2v_datadrivenplot_MELA",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 2500,
+            "spimpose": true,
+            "tag": "ggH(2500)_SOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M2500_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH2500toZZto2L2Nu_BOnly_MELA_powheg_2016",
+                    "split": 16,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot_SM",
+                "2l2v_datadrivenplot_MELA",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 2500,
+            "spimpose": true,
+            "tag": "ggH(2500)_BOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M2500_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH2500toZZto2L2Nu_SandBandInterf_MELA_powheg_2016",
+                    "split": 16,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot_SM",
+                "2l2v_datadrivenplot_MELA",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 2500,
+            "spimpose": true,
+            "tag": "ggH(2500)_SandBandInterf"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M3000_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH3000toZZto2L2Nu_SOnly_MELA_powheg_2016",
+                    "split": 16,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot_SM",
+                "2l2v_datadrivenplot_MELA",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 3000,
+            "spimpose": true,
+            "tag": "ggH(3000)_SOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M3000_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH3000toZZto2L2Nu_BOnly_MELA_powheg_2016",
+                    "split": 16,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot_SM",
+                "2l2v_datadrivenplot_MELA",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 3000,
+            "spimpose": true,
+            "tag": "ggH(3000)_BOnly"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/GluGluHToZZTo2L2Nu_M3000_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_GGtoH3000toZZto2L2Nu_SandBandInterf_MELA_powheg_2016",
+                    "split": 16,
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "2l2v_2016",
+                "2l2v_mcbased",
+                "2l2v_datadriven",
+                "2l2v_datadrivenplot_SM",
+                "2l2v_datadrivenplot_MELA",
+                "2l2v_datadriven_SM",
+                "2l2v_datadriven_MELA",
+                "2l2v_mcbased_SM",
+                "2l2v_mcbased_MELA"
+            ],
+            "lcolor": 619,
+            "lwidth": 2,
+            "resonance": 3000,
+            "spimpose": true,
+            "tag": "ggH(3000)_SandBandInterf"
+        }
+    ]
+}


### PR DESCRIPTION
do *not* use yet with current analysis code =>
- waiting for PR from Sumit to remove slew rate corrections for electrons
- JECs v3 are applied for jets in data . One can re-apply JECs v4 that are currently implemented by Li