### PR TITLE
updated Systematics for electron and Muon

### DIFF
--- a/bin/common/computeLimit.cc
+++ b/bin/common/computeLimit.cc
@@ -1747,8 +1747,8 @@ int main(int argc, char* argv[])
 
                  //Id+Trigger efficiencies combined
                  if(!it->second.isData){
-                    if(chbin.Contains("ee"  ))  shapeInfo.uncScale["CMS_eff_e"] = integral*0.05;    //4% (trigger) + 3% (Id+Iso)
-                    if(chbin.Contains("mumu"))  shapeInfo.uncScale["CMS_eff_m"] = integral*0.0424;  //4% (trigger) + 1% (Id) +1% (Iso)
+                    if(chbin.Contains("ee"  ))  shapeInfo.uncScale["CMS_eff_e"] = integral*0.035437;   
+                    if(chbin.Contains("mumu"))  shapeInfo.uncScale["CMS_eff_m"] = integral*0.030431;  
                  }
    
                  //uncertainties to be applied only in higgs analyses


### PR DESCRIPTION
Hi All,

We have updated systematics for Electron and Muon in computeLimit code.
These numbers are based on sum in quadrature of all the errors on SF coming from either Trigger SFs or ID and Iso SFs.

These numbers are produced with the help of @HuguesBrun and @amagitte .
I got these numbers  from Alessio today. 
In case of any question then please don't hesitate! 