### PR TITLE
some minor changes in electron's passID function

### DIFF
--- a/interface/PatUtils.h
+++ b/interface/PatUtils.h
@@ -82,7 +82,7 @@ namespace patUtils
    namespace CutVersion { enum CutSet {Spring15Cut25ns, ICHEP16Cut, Moriond17Cut}; }
 
    bool passId (VersionedPatElectronSelector id, edm::EventBase const & event, pat::Electron el);
-   bool passId (pat::Electron& el,  reco::Vertex& vtx, int IdLevel, int cutVersion); // Old PHYS14 ID
+   bool passId (pat::Electron& el,  reco::Vertex& vtx, int IdLevel, int cutVersion, bool is2016=true); // Old PHYS14 ID
    bool passId (pat::Muon&     mu,  reco::Vertex& vtx, int IdLevel, int cutVersion);
    bool passId (pat::Photon& photon,  double rho, int IdLevel);
    float relIso(patUtils::GenericLepton& lep, double rho);

--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -80,13 +80,17 @@ namespace patUtils
     return id(el, event);
   }
 
-  bool passId(pat::Electron& el,  reco::Vertex& vtx, int IdLevel, int cutVersion){
+  bool passId(pat::Electron& el,  reco::Vertex& vtx, int IdLevel, int cutVersion, bool is2016){
 
     //for electron Id look here: //https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Spring15_selection_25ns
     //for the meaning of the different cuts here: https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammaCutBasedIdentification
-    float dEtaln         = fabs(el.deltaEtaSuperClusterTrackAtVtx());
+
+    float dEtalnSeed = el.superCluster().isNonnull() && el.superCluster()->seed().isNonnull() ? el.deltaEtaSuperClusterTrackAtVtx() - el.superCluster()->eta() + el.superCluster()->seed()->eta() : std::numeric_limits<float>::max();
+
+    float dEtaln = is2016 ? dEtalnSeed : fabs(el.deltaEtaSuperClusterTrackAtVtx());
     float dPhiln         = fabs(el.deltaPhiSuperClusterTrackAtVtx());
-    float sigmaletaleta  = el.sigmaIetaIeta();
+//    float sigmaletaleta  = el.sigmaIetaIeta();
+    float sigmaletaleta  = el.full5x5_sigmaIetaIeta();
     float hem            = el.hadronicOverEm();
     double resol         = fabs((1/el.ecalEnergy())-(el.eSuperClusterOverP()/el.ecalEnergy()));
     double dxy           = fabs(el.gsfTrack()->dxy(vtx.position()));


### PR DESCRIPTION
Dear All,

Two variables one sigmaietaieta and other dEtaIn were not calculated in correct way in the code for electrons ID. This was pointed out by Alessio. So I have corrected those two variables following the link from twiki page[*].

[*] https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Working_points_for_2016_data_for


