### PR TITLE
Fix slew rate, incorprating Hugo's suggestions

### DIFF
--- a/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
+++ b/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
@@ -1270,6 +1270,7 @@ int main(int argc, char* argv[])
                 if(fabs(leptons[ilep].el.superCluster()->eta()) < 1.479)elDiff_forMET -= leptons[ilep].p4()*0.006;
                 else elDiff_forMET -= leptons[ilep].p4()*0.015;
                 if(!isMC){ utils::cmssw::SlewRateCorrection(ev,leptons[ilep].el); }
+               	leptons[ilep] = patUtils::GenericLepton(leptons[ilep].el); //recreate the generic lepton to be sure that the p4 is ok
                 if (isMC || is2015data || is2016data){
                 	ElectronEnCorrector.calibrate(leptons[ilep].el, ev.eventAuxiliary().run(), edm::StreamID::invalidStreamID());
                 	leptons[ilep] = patUtils::GenericLepton(leptons[ilep].el); //recreate the generic lepton to be sure that the p4 is ok

--- a/src/MacroUtils.cc
+++ b/src/MacroUtils.cc
@@ -439,10 +439,10 @@ namespace utils
        fwlite::Handle<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> > > _ebrechits;
        _ebrechits.getByLabel(ev,"reducedEgamma","reducedEBRecHits");
 
+        double Ecorr=1;
         if(fabs(ele.superCluster()->eta())<1.479){
         DetId detid = ele.superCluster()->seed()->seed();
         const EcalRecHit * rh = NULL;
-        double Ecorr=1;
         if (detid.subdetId() == EcalBarrel) {
            auto rh_i =  _ebrechits->find(detid);
                       if( rh_i != _ebrechits->end()) rh =  &(*rh_i);
@@ -454,9 +454,9 @@ namespace utils
         else if(rh->energy()>300 && rh->energy()<400) Ecorr=  1.052;
         else if(rh->energy()>400 && rh->energy()<500) Ecorr = 1.015;
       }
-       TLorentzVector p4(ele.px(),ele.py(),ele.pz(),ele.energy());
-       ele.setP4(LorentzVector(p4.Px(),p4.Py(),p4.Pz(),p4.E()*Ecorr ) );
         }
+       TLorentzVector p4(ele.px(),ele.py(),ele.pz(),ele.energy());
+       ele.setP4(LorentzVector(p4.Px()*Ecorr,p4.Py()*Ecorr,p4.Pz()*Ecorr,p4.E()*Ecorr ) );
     }
 
   }


### PR DESCRIPTION
Hi,

I have added all the suggestions from Hugo. But for double sure please check it first.
Here I made following changes.

In file runHZZ2l2vAnalsis.cc -- 
line 1273 : added leptons[ilep] = patUtils::GenericLepton(leptons[ilep].el); 

In file MacroUtils.cc --
1) Keep Ecorr=1 and TLorentzVector (line 458 and 459) outside the if condition. This if condition checks if the electron is in Barrel. Since this correction has to be applied only on Barrel Electron. So if electron is not in Barrel then Ecorr=1 and Electron will not get any slew correction.
2) Applied Ecorr on all px,py,pz and E. (line 459)

Sumit
