### PR TITLE
Small fix for optimize projection bin

### DIFF
--- a/test/hzz2l2v/computeLimit/optimize.py
+++ b/test/hzz2l2v/computeLimit/optimize.py
@@ -361,7 +361,7 @@ for signalSuffix in signalSuffixVec :
                      vals=line.split(' ')
                      for c in range(1, cutsH.GetYaxis().GetNbins()+3):
                         #FIXME FORCE INDEX TO BE 17 (Met>125GeV)
-                        Gcut[c-1].SetPoint(mi, 17, float(125));
+                        Gcut[c-1].SetPoint(mi, 17, float(130));
    #                     Gcut[c-1].SetPoint(mi, float(vals[0]), float(vals[c+1]));
                      mi+=1
                   for c in range(1, cutsH.GetYaxis().GetNbins()+3): Gcut[c-1].Set(mi);
@@ -371,7 +371,7 @@ for signalSuffix in signalSuffixVec :
                   for mtmp in SUBMASS:
                      for c in range(1, cutsH.GetYaxis().GetNbins()+3):
                         #FIXME FORCE INDEX TO BE 17 (Met>125GeV)
-                        Gcut[c-1].SetPoint(mi, 17, float(125));
+                        Gcut[c-1].SetPoint(mi, 17, float(130));
                      mi+=1
                   for c in range(1, cutsH.GetYaxis().GetNbins()+3): Gcut[c-1].Set(mi);
 

--- a/test/hzz2l2v/computeLimit/optimize_WideWidth.py
+++ b/test/hzz2l2v/computeLimit/optimize_WideWidth.py
@@ -372,7 +372,7 @@ for signalSuffix in signalSuffixVec :
                      vals=line.split(' ')
                      for c in range(1, cutsH.GetYaxis().GetNbins()+3):
                         #FIXME FORCE INDEX TO BE 17 (Met>125GeV)
-                        Gcut[c-1].SetPoint(mi, 17, float(125));
+                        Gcut[c-1].SetPoint(mi, 17, float(130));
    #                     Gcut[c-1].SetPoint(mi, float(vals[0]), float(vals[c+1]));
                      mi+=1
                   for c in range(1, cutsH.GetYaxis().GetNbins()+3): Gcut[c-1].Set(mi);
@@ -382,7 +382,7 @@ for signalSuffix in signalSuffixVec :
                   for mtmp in SUBMASS:
                      for c in range(1, cutsH.GetYaxis().GetNbins()+3):
                         #FIXME FORCE INDEX TO BE 17 (Met>125GeV)
-                        Gcut[c-1].SetPoint(mi, 17, float(125));
+                        Gcut[c-1].SetPoint(mi, 17, float(130));
                      mi+=1
                   for c in range(1, cutsH.GetYaxis().GetNbins()+3): Gcut[c-1].Set(mi);
 


### PR DESCRIPTION
This is a bit counter intuitive, I may think of a prettier fix when have time.
Since in the shapes we added one bin, we have to use the bin projection 17 instead of 16. However the optimize.py code performs some checks with the associated value and one has to increase the associated value accordingly (going from 125 to 130).
So this cut is really the one corresponding to 125 even if it can look different at first sight. I will improve this to make it more intuitive when having more time but the machinery was not meant to have a cut with 0 and then starting with cuts at 50, 55, 60 etc.