### PR TITLE
updates for single top samples + overlaps in X and X+g

### DIFF
--- a/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
+++ b/bin/hzz2l2v/runHZZ2l2vAnalysis.cc
@@ -132,6 +132,11 @@ int main(int argc, char* argv[])
   bool isMC_WZ3lnu  = isMC && ( string(dtag.Data()).find("TeV_WZ3lnu")  != string::npos);
   bool isMC_Wlnu_inclusive = (isMC && dtag.Contains("_WJets_") && !dtag.Contains("HT"));
   bool isMC_Wlnu_HT100 = (isMC && dtag.Contains("_WJets_HT-") );
+
+  bool isMC_WGToLNuG = (isMC && dtag.Contains("WGToLNuG") );      
+  bool isMC_ZNuNuGJets = (isMC && dtag.Contains("ZNuNuGJets")); 
+  bool isMC_ZJetsToNuNu = (isMC && dtag.Contains("ZJetsToNuNu")); 
+
   bool isMC_QCD = (isMC && dtag.Contains("QCD"));
   bool isMC_GJet = (isMC && dtag.Contains("GJet"));
   bool is2015data = (!isMC && dtag.Contains("2015"));
@@ -1139,7 +1144,9 @@ int main(int argc, char* argv[])
          }
 
          //Resolve G+jet/QCD mixing (avoid double counting of photons)
-         if (isMC_GJet || isMC_QCD ) {
+         if (isMC_GJet || isMC_QCD ||
+	     isMC_Wlnu_inclusive || isMC_Wlnu_HT100 || isMC_WGToLNuG || 
+             isMC_ZNuNuGJets || isMC_ZJetsToNuNu ) {
            // iF GJet sample; accept only event with prompt photons
            // if QCD sample; reject events with prompt photons in final state
              bool gPromptFound=false;
@@ -1148,6 +1155,10 @@ int main(int argc, char* argv[])
              }
              if ( (isMC_GJet) && (!gPromptFound) ) continue; //reject event
              if ( (isMC_QCD) && gPromptFound ) continue; //reject event
+	     if ( ( isMC_Wlnu_inclusive || isMC_Wlnu_HT100) && gPromptFound ) continue;
+             if ( (isMC_WGToLNuG) && (!gPromptFound) ) continue; 
+             if ( (isMC_ZNuNuGJets) && (!gPromptFound) ) continue; 
+             if ( (isMC_ZJetsToNuNu) && gPromptFound ) continue;
          }
 
   	 //Electroweak corrections to ZZ and WZ simulations

--- a/test/hzz2l2v/samples_full2016_GGH.json
+++ b/test/hzz2l2v/samples_full2016_GGH.json
@@ -693,15 +693,25 @@
                     "dtag": "MC13TeV_SingleT_s_2016",
                     "xsec": 3.362
                 },
+		{
+		   "br": [                                                                                                                                         
+                        1.0  
+                    ], 
+		    "dset": [ 
+		    	"/ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+		    ],
+		    "dtag": "MC13TeV_SingleT_at_2016",
+		    "xsec": 136.02 
+                },
                 {
                     "br": [
                         1.0
                     ],
                     "dset": [
-                        "/ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"
+                        "/ST_t-channel_antitop_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-                    "dtag": "MC13TeV_SingleT_t_2016_old",
-                    "xsec": 70.69
+                    "dtag": "MC13TeV_SingleT_t_2016",
+                    "xsec": 80.95
                 },
                 {
                     "br": [

--- a/test/hzz2l2v/samples_re-miniAOD_full2016_GGH.json
+++ b/test/hzz2l2v/samples_re-miniAOD_full2016_GGH.json
@@ -747,15 +747,26 @@
                     "dtag": "MC13TeV_SingleT_s_2016",
                     "xsec": 3.362
                 },
+		{
+                   "br": [ 
+                        1.0 
+                    ], 
+                    "dset": [ 
+		      "/ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_\
+2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ], 
+                    "dtag": "MC13TeV_SingleT_at_2016", 
+                    "xsec": 136.02 
+                },   
                 {
                     "br": [
                         1.0
                     ],
                     "dset": [
-                        "/ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM"
+                        "/ST_t-channel_antitop_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-                    "dtag": "MC13TeV_SingleT_t_2016_old",
-                    "xsec": 70.69
+                    "dtag": "MC13TeV_SingleT_t_2016",
+                    "xsec": 80.95
                 },
                 {
                     "br": [


### PR DESCRIPTION
- The t-channel samples for top and antitop had to be updated . In fact it seems we were completely ignoring the t-channel_top previously - we need to check now for any improvement in the data-MC agreement in the signal region . NRB needs to be redone as well .

- I also remove overlaps now between processes : W->lnu and Wg->lnug as well as Z->nunu and  Zg -> nunug in the same way as was done between plain QCD and G+jets. This is to improve the data-MC agreement in the photon control sample due to the genuine Met EWK processes.